### PR TITLE
Add YARN tests [test-yarn]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,22 +10,32 @@ branches:
   only:
     - master
 
-before_install:
-  - gimme 1.12
-  - source ~/.gimme/envs/go1.12.env
-  - go get github.com/stretchr/testify/assert
+jobs:
+    fast_finish: true
 
-install:
-  - source continuous_integration/install.sh
+    include:
+        - if: commit_message ~= test-yarn
+          services:
+            - docker
+          before_install:
+            - ./continuous_integration/docker/hadoop/start-hadoop.sh
+          install:
+            - docker exec master /working/continuous_integration/docker/hadoop/install.sh
+          script:
+            - docker exec master /working/continuous_integration/docker/hadoop/script.sh
 
-script:
-  - py.test tests/ -v
-  - flake8
-  - black . --check
-  - |
-    pushd dask-gateway-server/dask-gateway-proxy
-    go test
-    popd
+        - before_install:
+            - source continuous_integration/docker/hadoop/before_install.sh
+          install:
+            - source continuous_integration/install.sh
+          script:
+            - py.test tests/ -v
+            - flake8
+            - black . --check
+            - |
+              pushd dask-gateway-server/dask-gateway-proxy
+              go test
+              popd
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ jobs:
 
     include:
         - if: commit_message ~= test-yarn
+          env:
+            - MAIN-TESTS=true
           services:
             - docker
           before_install:
@@ -24,8 +26,10 @@ jobs:
           script:
             - docker exec master /working/continuous_integration/docker/hadoop/script.sh
 
-        - before_install:
-            - source continuous_integration/docker/hadoop/before_install.sh
+        - env:
+            - YARN-TESTS=true
+          before_install:
+            - source continuous_integration/before_install.sh
           install:
             - source continuous_integration/install.sh
           script:

--- a/continuous_integration/before_install.sh
+++ b/continuous_integration/before_install.sh
@@ -1,0 +1,3 @@
+gimme 1.12 \
+&& source ~/.gimme/envs/go1.12.env \
+&& go get github.com/stretchr/testify/assert

--- a/continuous_integration/docker/hadoop/Dockerfile
+++ b/continuous_integration/docker/hadoop/Dockerfile
@@ -1,0 +1,91 @@
+FROM centos:centos7
+MAINTAINER jcrist
+
+# Install common utilities
+RUN yum install -y \
+        sudo \
+        bzip2 \
+        java-1.8.0-openjdk \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+# Install kerberos
+RUN yum install -y \
+        krb5-libs \
+        krb5-server \
+        krb5-workstation \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+# Install hadoop
+RUN cd /etc/yum.repos.d/ && { curl -O https://archive.cloudera.com/cdh5/redhat/7/x86_64/cdh/cloudera-cdh5.repo ; cd -; } \
+    && rpm --import https://archive.cloudera.com/cdh5/redhat/7/x86_64/cdh/RPM-GPG-KEY-cloudera \
+    && yum install -y \
+        hadoop-yarn-resourcemanager \
+        hadoop-hdfs-namenode \
+        hadoop-yarn-nodemanager \
+        hadoop-hdfs-datanode \
+        hadoop-client \
+        hadoop-libhdfs \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+# Install supervisord
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python get-pip.py \
+    && pip install supervisor \
+    && rm get-pip.py
+
+# Install fixuid
+RUN curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - \
+    && chown root:root /usr/local/bin/fixuid \
+    && chmod 4755 /usr/local/bin/fixuid \
+    && echo "root ALL=(ALL:ALL) NOPASSWD: /usr/local/bin/fixuid" >> /etc/sudoers
+
+# Make a few user accounts
+RUN useradd -m dask
+RUN useradd -m alice
+RUN useradd -m bob
+
+# Install miniconda
+RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
+    && /bin/bash /tmp/miniconda.sh -b -p /opt/miniconda \
+    && rm /tmp/miniconda.sh \
+    && /opt/miniconda/bin/conda update conda -y \
+    && /opt/miniconda/bin/conda config --set always_yes yes --set changeps1 no \
+    && /opt/miniconda/bin/conda clean -a \
+    && find /opt/miniconda/ -type f -name '*.a' -delete \
+    && find /opt/miniconda/ -type f -name '*.js.map' -delete \
+    && find /opt/miniconda/ -type f -name '*.pyc' -delete \
+    && rm -rf /opt/miniconda/pkgs \
+    && find /opt/miniconda/ -type f -name '*.so' -exec strip --strip-all {} + || true
+
+# Install go
+RUN curl https://dl.google.com/go/go1.12.2.linux-amd64.tar.gz -o /tmp/go.tar.gz \
+    && tar -xzf /tmp/go.tar.gz -C /opt/ \
+    && rm /tmp/go.tar.gz
+
+RUN echo 'export PATH="/opt/go/bin:/opt/miniconda/bin:$PATH"' >> ~/.bashrc
+
+# Copy over files
+COPY ./files /
+
+# Fix container-executor permissions
+RUN chmod 6050 /etc/hadoop/conf.kerberos/container-executor.cfg
+
+# Configure and setup hadoop
+RUN /root/setup-hadoop.sh
+
+# Setup kerberos
+RUN /root/setup-kerb.sh
+
+ENV JAVA_HOME /usr/lib/jvm/jre-openjdk
+ENV LIBHDFS3_CONF /etc/hadoop/conf/hdfs-site.xml
+ENV HADOOP_CONF_DIR /etc/hadoop/conf
+ENV HADOOP_HOME /usr/lib/hadoop
+ENV HADOOP_COMMON_HOME /usr/lib/hadoop
+ENV HADOOP_YARN_HOME /usr/lib/hadoop-yarn
+ENV HADOOP_HDFS_HOME /usr/lib/hadoop-hdfs
+ENV TEST_DASK_GATEWAY_YARN true
+
+CMD ["supervisord", "--configuration", "/etc/supervisord.conf"]

--- a/continuous_integration/docker/hadoop/files/etc/fixuid/config.yaml
+++ b/continuous_integration/docker/hadoop/files/etc/fixuid/config.yaml
@@ -1,0 +1,4 @@
+user: dask
+group: dask
+paths:
+    - /home/dask

--- a/continuous_integration/docker/hadoop/files/etc/hadoop/conf.kerberos/capacity-scheduler.xml
+++ b/continuous_integration/docker/hadoop/files/etc/hadoop/conf.kerberos/capacity-scheduler.xml
@@ -1,0 +1,81 @@
+<configuration>
+  <!--
+    The following queue structures is used:
+      - default (cap: 60%, max: 100%)
+      - fruit (cap: 40%, max: 50%)
+        - apples (cap: 50%, max: 100%)
+        - bananas (cap: 25%, max: 50%)
+        - oranges (cap: 25%, max: 60%)
+  -->
+
+  <property>
+    <name>yarn.scheduler.capacity.root.queues</name>
+    <value>default,fruit</value>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.fruit.queues</name>
+    <value>apples,bananas,oranges</value>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.maximum-am-resource-percent</name>
+    <value>0.75</value>
+  </property>
+
+  <!-- root.default -->
+  <property>
+    <name>yarn.scheduler.capacity.root.default.capacity</name>
+    <value>60.0</value>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.default.maximum-capacity</name>
+    <value>100.0</value>
+  </property>
+
+  <!-- root.fruit -->
+  <property>
+    <name>yarn.scheduler.capacity.root.fruit.capacity</name>
+    <value>40.0</value>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.fruit.maximum-capacity</name>
+    <value>50.0</value>
+  </property>
+
+  <!-- root.fruit.apples -->
+  <property>
+    <name>yarn.scheduler.capacity.root.fruit.apples.capacity</name>
+    <value>50.0</value>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.fruit.apples.maximum-capacity</name>
+    <value>100.0</value>
+  </property>
+
+  <!-- root.fruit.bananas -->
+  <property>
+    <name>yarn.scheduler.capacity.root.fruit.bananas.capacity</name>
+    <value>25.0</value>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.fruit.bananas.maximum-capacity</name>
+    <value>50.0</value>
+  </property>
+
+  <!-- root.fruit.oranges -->
+  <property>
+    <name>yarn.scheduler.capacity.root.fruit.oranges.capacity</name>
+    <value>25.0</value>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.fruit.oranges.maximum-capacity</name>
+    <value>60.0</value>
+  </property>
+
+</configuration>

--- a/continuous_integration/docker/hadoop/files/etc/hadoop/conf.kerberos/container-executor.cfg
+++ b/continuous_integration/docker/hadoop/files/etc/hadoop/conf.kerberos/container-executor.cfg
@@ -1,0 +1,6 @@
+yarn.nodemanager.local-dirs=/var/lib/hadoop-yarn/cache/yarn/nm-local-dir
+yarn.nodemanager.linux-container-executor.group=yarn
+yarn.nodemanager.log-dirs=/var/log/hadoop-yarn/containers
+banned.users=hdfs,yarn,mapred,bin
+
+min.user.id=500

--- a/continuous_integration/docker/hadoop/files/etc/hadoop/conf.kerberos/core-site.xml
+++ b/continuous_integration/docker/hadoop/files/etc/hadoop/conf.kerberos/core-site.xml
@@ -1,0 +1,78 @@
+<configuration>
+
+    <property>
+        <name>hadoop.tmp.dir</name>
+        <value>/var/tmp/</value>
+    </property>
+
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://master.example.com:9000</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.mapred.hosts</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.mapred.groups</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.dask.hosts</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.dask.users</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.security.authentication</name>
+        <value>kerberos</value>
+    </property>
+
+    <property>
+        <name>hadoop.security.authorization</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.filter.initializers</name>
+        <value>org.apache.hadoop.security.AuthenticationFilterInitializer</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.authentication.type</name>
+        <value>kerberos</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.authentication.signature.secret.file</name>
+        <value>/etc/hadoop/conf/http-secret-file</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.authentication.cookie.domain</name>
+        <value>.example.com</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.authentication.simple.anonymous.allowed</name>
+        <value>false</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.authentication.kerberos.principal</name>
+        <value>HTTP/master.example.com@EXAMPLE.COM</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.authentication.kerberos.keytab</name>
+        <value>/etc/hadoop/conf/master-keytabs/HTTP.keytab</value>
+    </property>
+
+</configuration>

--- a/continuous_integration/docker/hadoop/files/etc/hadoop/conf.kerberos/hdfs-site.xml
+++ b/continuous_integration/docker/hadoop/files/etc/hadoop/conf.kerberos/hdfs-site.xml
@@ -1,0 +1,68 @@
+<configuration>
+
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+
+    <property>
+        <name>dfs.permissions.enabled</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>dfs.webhdfs.enabled</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>dfs.block.access.token.enable</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>dfs.namenode.keytab.file</name>
+        <value>/etc/hadoop/conf/master-keytabs/hdfs.keytab</value>
+    </property>
+
+    <property>
+        <name>dfs.namenode.kerberos.principal</name>
+        <value>hdfs/master.example.com@EXAMPLE.COM</value>
+    </property>
+
+    <property>
+        <name>dfs.namenode.kerberos.internal.spnego.principal</name>
+        <value>HTTP/master.example.com@EXAMPLE.COM</value>
+    </property>
+
+    <property>
+        <name>dfs.datanode.keytab.file</name>
+        <value>/etc/hadoop/conf/master-keytabs/hdfs.keytab</value>
+    </property>
+
+    <property>
+        <name>dfs.datanode.kerberos.principal</name>
+        <value>hdfs/master.example.com@EXAMPLE.COM</value>
+	</property>
+
+    <property>
+        <name>dfs.web.authentication.kerberos.principal</name>
+        <value>HTTP/master.example.com@EXAMPLE.COM</value>
+    </property>
+
+    <property>
+        <name>dfs.web.authentication.kerberos.keytab</name>
+        <value>/etc/hadoop/conf/master-keytabs/HTTP.keytab</value>
+    </property>
+
+    <property>
+        <name>ignore.secure.ports.for.testing</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>dfs.http.policy</name>
+        <value>HTTP_ONLY</value>
+	</property>
+
+</configuration>

--- a/continuous_integration/docker/hadoop/files/etc/hadoop/conf.kerberos/mapred-site.xml
+++ b/continuous_integration/docker/hadoop/files/etc/hadoop/conf.kerberos/mapred-site.xml
@@ -1,0 +1,28 @@
+<configuration>
+
+    <property>
+        <name>mapreduce.framework.name</name>
+        <value>yarn</value>
+    </property>
+
+    <property>
+        <name>mapreduce.jobhistory.address</name>
+        <value>master.example.com:10020</value>
+    </property>
+
+    <property>
+        <name>mapreduce.jobhistory.webapp.address</name>
+        <value>master.example.com:19888</value>
+    </property>
+
+    <property>
+        <name>mapreduce.jobhistory.keytab</name>
+        <value>/etc/hadoop/conf/master-keytabs/mapred.keytab</value>
+    </property>
+
+    <property>
+        <name>mapreduce.jobhistory.principal</name>
+        <value>mapred/master.example.com@EXAMPLE.COM</value>
+    </property>
+
+</configuration>

--- a/continuous_integration/docker/hadoop/files/etc/hadoop/conf.kerberos/yarn-site.xml
+++ b/continuous_integration/docker/hadoop/files/etc/hadoop/conf.kerberos/yarn-site.xml
@@ -1,0 +1,108 @@
+<configuration>
+
+    <property>
+        <name>yarn.resourcemanager.hostname</name>
+        <value>master.example.com</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.aux-services</name>
+        <value>mapreduce_shuffle</value>
+    </property>
+
+    <property>
+        <name>yarn.application.classpath</name>
+        <value>
+        $HADOOP_CONF_DIR,
+        $HADOOP_COMMON_HOME/*,
+        $HADOOP_COMMON_HOME/lib/*,
+        $HADOOP_HDFS_HOME/*,
+        $HADOOP_HDFS_HOME/lib/*,
+        $HADOOP_MAPRED_HOME/*,
+        $HADOOP_MAPRED_HOME/lib/*,
+        $HADOOP_YARN_HOME/*,
+        $HADOOP_YARN_HOME/lib/*
+        </value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.local-dirs</name>
+        <value>file:///var/tmp/hadoop-yarn/local</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.log-dirs</name>
+        <value>file:///var/tmp/hadoop-yarn/logs</value>
+    </property>
+
+    <property>
+        <name>yarn.log-aggregation-enable</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.remote-app-log-dir</name>
+        <value>hdfs://master.example.com:9000/var/log/hadoop-yarn/apps</value>
+    </property>
+
+    <property>
+        <name>yarn.scheduler.minimum-allocation-mb</name>
+        <value>32</value>
+    </property>
+
+    <property>
+        <name>yarn.resource-types.memory-mb.increment-allocation</name>
+        <value>${yarn.scheduler.minimum-allocation-mb}</value>
+    </property>
+
+    <property>
+        <name>yarn.scheduler.increment-allocation-mb</name>
+        <value>${yarn.scheduler.minimum-allocation-mb}</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.resource.cpu-vcores</name>
+        <value>16</value>
+    </property>
+
+    <property>
+      <name>yarn.resourcemanager.scheduler.class</name>
+      <value>org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.keytab</name>
+        <value>/etc/hadoop/conf/master-keytabs/yarn.keytab</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.principal</name>
+        <value>yarn/master.example.com@EXAMPLE.COM</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.keytab</name>
+        <value>/etc/hadoop/conf/master-keytabs/yarn.keytab</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.principal</name>
+        <value>yarn/master.example.com@EXAMPLE.COM</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.container-executor.class</name>
+        <value>org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.linux-container-executor.path</name>
+        <value>/usr/lib/hadoop-yarn/bin/container-executor</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.linux-container-executor.group</name>
+        <value>yarn</value>
+    </property>
+
+</configuration>

--- a/continuous_integration/docker/hadoop/files/etc/hadoop/conf.simple/core-site.xml
+++ b/continuous_integration/docker/hadoop/files/etc/hadoop/conf.simple/core-site.xml
@@ -1,0 +1,58 @@
+<configuration>
+
+    <property>
+        <name>hadoop.tmp.dir</name>
+        <value>/var/tmp/</value>
+    </property>
+
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://master.example.com:9000</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.mapred.hosts</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.mapred.groups</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.security.authentication</name>
+        <value>simple</value>
+    </property>
+
+    <property>
+        <name>hadoop.security.authorization</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.filter.initializers</name>
+        <value>org.apache.hadoop.security.AuthenticationFilterInitializer</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.authentication.type</name>
+        <value>simple</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.authentication.signature.secret.file</name>
+        <value>/etc/hadoop/conf/http-secret-file</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.authentication.cookie.domain</name>
+        <value>.example.com</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.authentication.simple.anonymous.allowed</name>
+        <value>false</value>
+    </property>
+
+</configuration>

--- a/continuous_integration/docker/hadoop/files/etc/hadoop/conf.simple/hdfs-site.xml
+++ b/continuous_integration/docker/hadoop/files/etc/hadoop/conf.simple/hdfs-site.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+
+    <property>
+        <name>dfs.permissions.enabled</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>dfs.webhdfs.enabled</name>
+        <value>true</value>
+    </property>
+
+</configuration>

--- a/continuous_integration/docker/hadoop/files/etc/krb5.conf
+++ b/continuous_integration/docker/hadoop/files/etc/krb5.conf
@@ -1,0 +1,18 @@
+[logging]
+ default = FILE:/var/log/krb5libs.log
+ kdc = FILE:/var/log/krb5kdc.log
+ admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+ default_realm = EXAMPLE.COM
+ dns_lookup_realm = false
+ dns_lookup_kdc = false
+ ticket_lifetime = 24h
+ renew_lifetime = 7d
+ forwardable = true
+
+[realms]
+ EXAMPLE.COM = {
+  kdc = master.example.com
+  admin_server = master.example.com
+}

--- a/continuous_integration/docker/hadoop/files/etc/supervisord.conf
+++ b/continuous_integration/docker/hadoop/files/etc/supervisord.conf
@@ -1,0 +1,18 @@
+[supervisord]
+strip_ansi = true
+nodaemon = true
+logfile = /var/log/supervisord.log
+pidfile = /var/run/supervisord.pid
+
+[unix_http_server]
+file = /tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl = unix:///tmp/supervisor.sock
+prompt = hadoop
+
+[include]
+files = /etc/supervisord.d/*.conf

--- a/continuous_integration/docker/hadoop/files/etc/supervisord.d/fixuid.conf
+++ b/continuous_integration/docker/hadoop/files/etc/supervisord.d/fixuid.conf
@@ -1,0 +1,7 @@
+[program:fixuid]
+command=/root/fixuid.sh
+startsecs=0
+redirect_stderr=true
+stdout_logfile=/var/log/fixuid.log
+autostart=true
+autorestart=false

--- a/continuous_integration/docker/hadoop/files/etc/supervisord.d/hdfs-datanode.conf
+++ b/continuous_integration/docker/hadoop/files/etc/supervisord.d/hdfs-datanode.conf
@@ -1,0 +1,9 @@
+[program:hdfs-datanode]
+command=hdfs datanode
+startsecs=2
+stopwaitsecs=10
+user=hdfs
+redirect_stderr=true
+stdout_logfile=/var/log/hadoop-hdfs/hadoop-hdfs-datanode.log
+autostart=true
+autorestart=false

--- a/continuous_integration/docker/hadoop/files/etc/supervisord.d/hdfs-namenode.conf
+++ b/continuous_integration/docker/hadoop/files/etc/supervisord.d/hdfs-namenode.conf
@@ -1,0 +1,9 @@
+[program:hdfs-namenode]
+command=hdfs namenode
+startsecs=2
+stopwaitsecs=10
+user=hdfs
+redirect_stderr=true
+stdout_logfile=/var/log/hadoop-hdfs/hadoop-hdfs-namenode.log
+autostart=true
+autorestart=false

--- a/continuous_integration/docker/hadoop/files/etc/supervisord.d/kerberos.conf
+++ b/continuous_integration/docker/hadoop/files/etc/supervisord.d/kerberos.conf
@@ -1,0 +1,15 @@
+[program:krb5kdc]
+command=/bin/bash -c "exec /usr/sbin/krb5kdc -r EXAMPLE.COM -P /var/run/krb5kdc.pid -n"
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+autostart=true
+autorestart=true
+
+[program:kadmind]
+command=/bin/bash -c "exec /usr/sbin/kadmind -r EXAMPLE.COM -P /var/run/kadmind.pid -nofork"
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+autostart=true
+autorestart=true

--- a/continuous_integration/docker/hadoop/files/etc/supervisord.d/yarn-nodemanager.conf
+++ b/continuous_integration/docker/hadoop/files/etc/supervisord.d/yarn-nodemanager.conf
@@ -1,0 +1,9 @@
+[program:yarn-nodemanager]
+command=yarn nodemanager
+startsecs=2
+stopwaitsecs=10
+user=yarn
+redirect_stderr=true
+stdout_logfile=/var/log/hadoop-yarn/hadoop-yarn-nodemanager.log
+autostart=true
+autorestart=false

--- a/continuous_integration/docker/hadoop/files/etc/supervisord.d/yarn-resourcemanager.conf
+++ b/continuous_integration/docker/hadoop/files/etc/supervisord.d/yarn-resourcemanager.conf
@@ -1,0 +1,9 @@
+[program:yarn-resourcemanager]
+command=yarn resourcemanager
+startsecs=2
+stopwaitsecs=10
+user=yarn
+redirect_stderr=true
+stdout_logfile=/var/log/hadoop-yarn/hadoop-yarn-resourcemanager.log
+autostart=true
+autorestart=false

--- a/continuous_integration/docker/hadoop/files/root/fixuid.sh
+++ b/continuous_integration/docker/hadoop/files/root/fixuid.sh
@@ -1,0 +1,2 @@
+#! /usr/bin/env bash
+sudo -u "#$HADOOP_TESTING_FIXUID" -g "#$HADOOP_TESTING_FIXGID" /usr/local/bin/fixuid

--- a/continuous_integration/docker/hadoop/files/root/init-hdfs.sh
+++ b/continuous_integration/docker/hadoop/files/root/init-hdfs.sh
@@ -1,0 +1,58 @@
+#! /bin/bash
+
+# Exponential backoff on testing hdfs status, then run init script
+echo "Waiting to connect to HDFS"
+timeout=2
+exit_code=0
+for attempt in {1..5}; do
+    hdfs dfs -ls /
+    exit_code=$?
+
+    if [[ $exit_code == 0 ]]; then
+        break
+    fi
+
+    echo "Retrying in $timeout.." 1>&2
+    sleep $timeout
+    timeout=$[$timeout * 2]
+done
+
+if [[ $exit_code != 0 ]]; then
+    echo "Failed to connect to HDFS"
+    exit $exit_code
+fi
+echo "HDFS connected, initializing directory structure"
+
+hdfs dfs -mkdir -p /tmp \
+&& hdfs dfs -chmod -R 1777 /tmp \
+&& hdfs dfs -mkdir -p /var/log \
+&& hdfs dfs -chmod -R 1775 /var/log \
+&& hdfs dfs -chown yarn:hadoop /var/log \
+&& hdfs dfs -mkdir -p /tmp/hadoop-yarn \
+&& hdfs dfs -chown -R mapred:hadoop /tmp/hadoop-yarn \
+&& hdfs dfs -mkdir -p /tmp/hadoop-yarn/staging/history/done_intermediate \
+&& hdfs dfs -chown -R mapred:hadoop /tmp/hadoop-yarn/staging \
+&& hdfs dfs -chmod -R 1777 /tmp \
+&& hdfs dfs -mkdir -p /var/log/hadoop-yarn/apps \
+&& hdfs dfs -chmod -R 1777 /var/log/hadoop-yarn/apps \
+&& hdfs dfs -chown yarn:hadoop /var/log/hadoop-yarn/apps \
+&& hdfs dfs -mkdir -p /user \
+&& hdfs dfs -mkdir -p /user/root \
+&& hdfs dfs -chmod -R 777 /user/root \
+&& hdfs dfs -chown root /user/root \
+&& hdfs dfs -mkdir -p /user/history \
+&& hdfs dfs -chmod -R 1777 /user/history \
+&& hdfs dfs -chown mapred:hadoop /user/history \
+&& hdfs dfs -mkdir -p /user/dask \
+&& hdfs dfs -chown dask /user/dask \
+&& hdfs dfs -mkdir -p /user/alice \
+&& hdfs dfs -chown alice /user/alice \
+&& hdfs dfs -mkdir -p /user/bob \
+&& hdfs dfs -chown bob /user/bob
+
+exit_code=$?
+if [[ $exit_code != 0 ]]; then
+    echo "Failed to initialize HDFS"
+    exit $exit_code
+fi
+echo "Initialized HDFS"

--- a/continuous_integration/docker/hadoop/files/root/init-shell.sh
+++ b/continuous_integration/docker/hadoop/files/root/init-shell.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Wait for fixuid to have finished
+if [[ "$HADOOP_TESTING_FIXUID" != "" ]]; then
+    while [[ ! -f /var/run/fixuid.ran ]]
+    do
+        sleep 1
+    done
+fi
+
+# cd into home directory
+cd
+
+# initialize as if login shell
+if [ -f .bash_profile ]; then
+    source .bash_profile;
+fi

--- a/continuous_integration/docker/hadoop/files/root/run_command.sh
+++ b/continuous_integration/docker/hadoop/files/root/run_command.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+source /root/init-shell.sh
+$@

--- a/continuous_integration/docker/hadoop/files/root/setup-hadoop.sh
+++ b/continuous_integration/docker/hadoop/files/root/setup-hadoop.sh
@@ -1,0 +1,33 @@
+# /bin/bash
+
+set -ex
+
+# Configure HDFS
+ln -s /etc/hadoop/conf.empty/log4j.properties /etc/hadoop/conf.simple/log4j.properties \
+    && ln -s /etc/hadoop/conf.empty/log4j.properties /etc/hadoop/conf.kerberos/log4j.properties \
+    && alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.simple 50 \
+    && alternatives --set hadoop-conf /etc/hadoop/conf.simple
+
+# Create yarn directories with proper permissions
+mkdir -p /var/tmp/hadoop-yarn/local /var/tmp/hadoop-yarn/logs \
+    && chown -R yarn:yarn /var/tmp/hadoop-yarn/local /var/tmp/hadoop-yarn/logs
+
+# Create secret key to authenticate web access
+dd if=/dev/urandom bs=64 count=1 > /etc/hadoop/conf/http-secret-file
+chown hdfs:hadoop /etc/hadoop/conf/http-secret-file
+chmod 440 /etc/hadoop/conf/http-secret-file
+
+# Format namenode
+sudo -E -u hdfs bash -c "hdfs namenode -format -force"
+
+# Format filesystem
+# XXX: Add to hosts to resolve name temporarily
+echo "127.0.0.1 master.example.com" >> /etc/hosts
+sudo -E -u hdfs bash -c "hdfs namenode"&
+sudo -E -u hdfs bash -c "hdfs datanode"&
+sudo -E -u hdfs /root/init-hdfs.sh
+killall java
+
+# Install conf.kerberos as final conf
+alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.kerberos 50 \
+&& alternatives --set hadoop-conf /etc/hadoop/conf.kerberos

--- a/continuous_integration/docker/hadoop/files/root/setup-kerb.sh
+++ b/continuous_integration/docker/hadoop/files/root/setup-kerb.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+
+create_keytabs() {
+    HOST="$1.example.com"
+    KEYTABS="/etc/hadoop/conf.kerberos/$1-keytabs"
+    kadmin.local -q "addprinc -randkey hdfs/$HOST@EXAMPLE.COM" \
+    && kadmin.local -q "addprinc -randkey mapred/$HOST@EXAMPLE.COM" \
+    && kadmin.local -q "addprinc -randkey yarn/$HOST@EXAMPLE.COM" \
+    && kadmin.local -q "addprinc -randkey HTTP/$HOST@EXAMPLE.COM" \
+    && mkdir "$KEYTABS" \
+    && kadmin.local -q "xst -norandkey -k $KEYTABS/hdfs.keytab hdfs/$HOST HTTP/$HOST" \
+    && kadmin.local -q "xst -norandkey -k $KEYTABS/mapred.keytab mapred/$HOST HTTP/$HOST" \
+    && kadmin.local -q "xst -norandkey -k $KEYTABS/yarn.keytab yarn/$HOST HTTP/$HOST" \
+    && kadmin.local -q "xst -norandkey -k $KEYTABS/HTTP.keytab HTTP/$HOST" \
+    && chown hdfs:hadoop $KEYTABS/hdfs.keytab \
+    && chown mapred:hadoop $KEYTABS/mapred.keytab \
+    && chown yarn:hadoop $KEYTABS/yarn.keytab \
+    && chown hdfs:hadoop $KEYTABS/HTTP.keytab \
+    && chmod 440 $KEYTABS/*.keytab
+}
+
+kdb5_util create -s -P testpass \
+&& create_keytabs master \
+&& kadmin.local -q "addprinc -pw adminpass root/admin" \
+&& kadmin.local -q "addprinc -pw testpass dask" \
+&& kadmin.local -q "addprinc -pw testpass alice" \
+&& kadmin.local -q "addprinc -pw testpass bob" \
+&& kadmin.local -q "xst -norandkey -k /home/dask/dask.keytab dask" \
+&& chown dask:dask /home/dask/dask.keytab

--- a/continuous_integration/docker/hadoop/files/var/kerberos/krb5kdc/kadm5.acl
+++ b/continuous_integration/docker/hadoop/files/var/kerberos/krb5kdc/kadm5.acl
@@ -1,0 +1,1 @@
+root/admin@EXAMPLE.COM     ex

--- a/continuous_integration/docker/hadoop/files/var/kerberos/krb5kdc/kdc.conf
+++ b/continuous_integration/docker/hadoop/files/var/kerberos/krb5kdc/kdc.conf
@@ -1,0 +1,11 @@
+[kdcdefaults]
+ kdc_ports = 88
+ kdc_tcp_ports = 88
+
+[realms]
+ EXAMPLE.COM = {
+  acl_file = /var/kerberos/krb5kdc/kadm5.acl
+  dict_file = /usr/share/dict/words
+  admin_keytab = /var/kerberos/krb5kdc/kadm5.keytab
+  supported_enctypes = des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
+}

--- a/continuous_integration/docker/hadoop/install.sh
+++ b/continuous_integration/docker/hadoop/install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+source ~/.bashrc
+
+set -xe
+
+cd /working
+
+conda install psutil
+
+pip install \
+    dask \
+    distributed \
+    cryptography \
+    tornado \
+    traitlets \
+    sqlalchemy \
+    skein \
+    pytest \
+    pytest-asyncio
+
+pushd dask-gateway
+python setup.py develop
+popd
+
+pushd dask-gateway-server
+python setup.py develop
+popd
+
+pip list

--- a/continuous_integration/docker/hadoop/script.sh
+++ b/continuous_integration/docker/hadoop/script.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+source ~/.bashrc
+
+set -xe
+
+cd /working
+
+py.test tests/test_yarn_cluster.py -v

--- a/continuous_integration/docker/hadoop/start-hadoop.sh
+++ b/continuous_integration/docker/hadoop/start-hadoop.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -xe
+
+ci_docker_hadoop="$(dirname "${BASH_SOURCE[0]}")"
+full_path_ci_docker_hadoop="$(cd "${ci_docker_hadoop}" && pwd)"
+git_root="$(cd "${full_path_ci_docker_hadoop}/../../.." && pwd)"
+
+docker run --rm -d \
+    --name master \
+    -h master.example.com \
+    -v "$git_root":/working \
+    jcrist/dask-gateway-hadoop-testing

--- a/tests/test_local_cluster.py
+++ b/tests/test_local_cluster.py
@@ -4,7 +4,9 @@ from .utils import ClusterManagerTests, LocalTestingClusterManager
 
 
 class TestLocalClusterManager(ClusterManagerTests):
-    async def cleanup_cluster(self, manager, cluster_state, worker_states):
+    async def cleanup_cluster(
+        self, manager, cluster_info, cluster_state, worker_states
+    ):
         for state in worker_states + [cluster_state]:
             pid = state.get("pid")
             if pid is not None:
@@ -13,11 +15,11 @@ class TestLocalClusterManager(ClusterManagerTests):
     def new_manager(self, **kwargs):
         return LocalTestingClusterManager(**kwargs)
 
-    def is_cluster_running(self, cluster_state):
+    def is_cluster_running(self, manager, cluster_info, cluster_state):
         pid = cluster_state.get("pid")
         return is_running(pid) if pid is not None else False
 
-    def is_worker_running(self, cluster_state, worker_state):
+    def is_worker_running(self, manager, cluster_info, cluster_state, worker_state):
         pid = worker_state.get("pid")
         return is_running(pid) if pid is not None else False
 

--- a/tests/test_yarn_cluster.py
+++ b/tests/test_yarn_cluster.py
@@ -1,0 +1,94 @@
+import os
+import pytest
+
+skein = pytest.importorskip("skein")
+
+if not os.environ.get("TEST_DASK_GATEWAY_YARN"):
+    pytest.skip("Not running YARN tests", allow_module_level=True)
+
+from dask_gateway_server.yarn_cluster import YarnClusterManager
+
+from .utils import ClusterManagerTests
+
+
+pytestmark = pytest.mark.usefixtures("cleanup_applications")
+
+
+_APPIDS = set()
+
+
+@pytest.fixture(scope="module")
+def cleanup_applications():
+    yield
+
+    if not _APPIDS:
+        return
+
+    with skein.Client(principal="dask", keytab="/home/dask/dask.keytab") as client:
+        for appid in _APPIDS:
+            try:
+                client.kill_application(appid)
+            except OSError:
+                pass
+    print("-- Stopped %d lost clusters --" % len(_APPIDS))
+
+
+class YarnTestingClusterManager(YarnClusterManager):
+    async def start_cluster(self, *args, **kwargs):
+        async for state in super().start_cluster(*args, **kwargs):
+            _APPIDS.add(state["app_id"])
+            yield state
+
+    async def stop_cluster(self, cluster_info, cluster_state):
+        appid = cluster_state.get("app_id")
+        await super().stop_cluster(cluster_info, cluster_state)
+        _APPIDS.discard(appid)
+
+
+class TestYarnClusterManager(ClusterManagerTests):
+    async def cleanup_cluster(
+        self, manager, cluster_info, cluster_state, worker_states
+    ):
+        app_id = cluster_state.get("app_id")
+        if app_id is not None:
+            manager.skein_client.kill_application(app_id)
+
+    def new_manager(self, **kwargs):
+        return YarnTestingClusterManager(
+            scheduler_cmd="/opt/miniconda/bin/dask-gateway-scheduler",
+            worker_cmd="/opt/miniconda/bin/dask-gateway-worker",
+            keytab="/home/dask/dask.keytab",
+            principal="dask",
+            scheduler_memory="512M",
+            worker_memory="512M",
+            scheduler_cores=1,
+            worker_cores=1,
+            cluster_start_timeout=30,
+            **kwargs,
+        )
+
+    def is_cluster_running(self, manager, cluster_info, cluster_state):
+        app_id = cluster_state.get("app_id")
+        if not app_id:
+            return False
+        report = manager.skein_client.application_report(app_id)
+        return report.state not in ("FINISHED", "FAILED", "KILLED")
+
+    def is_worker_running(self, manager, cluster_info, cluster_state, worker_state):
+        app_id = cluster_state.get("app_id")
+        container_id = worker_state.get("container_id")
+        if not app_id or not container_id:
+            return False
+
+        app = manager._get_app_client(cluster_info, cluster_state)
+
+        active = app.get_containers(
+            services=["dask.worker"], states=["WAITING", "REQUESTED", "RUNNING"]
+        )
+        return container_id in [c.id for c in active]
+
+    def num_start_cluster_stages(self):
+        return 2
+
+    def num_start_worker_stages(self):
+        return 1


### PR DESCRIPTION
- Adds a docker image for running a tiny realistic hadoop cluster
- Adds tests for YarnClusterManager
- Adds travis ci setup for yarn

Right now the yarn tests are only setup to run if [test-yarn] is in the
git commit. Depending on test time we may want to run them always, not
sure.