### PR TITLE
Cleanup db handling

### DIFF
--- a/dask-gateway-server/dask_gateway_server/app.py
+++ b/dask-gateway-server/dask_gateway_server/app.py
@@ -5,7 +5,6 @@ import os
 import socket
 import stat
 import tempfile
-import uuid
 import weakref
 from functools import partial
 from urllib.parse import urlparse, urlunparse
@@ -24,7 +23,6 @@ from .cluster import ClusterManager
 from .auth import Authenticator
 from .objects import WorkerStatus, ClusterStatus
 from .proxy import SchedulerProxy, WebProxy
-from .tls import new_keypair
 from .utils import cleanup_tmpdir, cancel_task
 
 
@@ -252,7 +250,6 @@ class DaskGateway(Application):
         self.init_cluster_manager()
         self.init_authenticator()
         self.init_tornado_application()
-        self.init_state()
 
     def init_logging(self):
         # Prevent double log messages from tornado
@@ -271,7 +268,7 @@ class DaskGateway(Application):
         logger.setLevel(self.log.level)
 
     def init_database(self):
-        self.db = objects.make_engine(url=self.db_url, echo=self.db_debug)
+        self.db = objects.DataManager(url=self.db_url, echo=self.db_debug)
 
     def init_tempdir(self):
         if os.path.exists(self.temp_dir):
@@ -285,55 +282,6 @@ class DaskGateway(Application):
             self.log.debug("Creating temporary directory %r", self.temp_dir)
             os.mkdir(self.temp_dir, mode=0o700)
             weakref.finalize(self, cleanup_tmpdir, self.log, self.temp_dir)
-
-    def init_state(self):
-        self.username_to_user = {}
-        self.cookie_to_user = {}
-        self.token_to_cluster = {}
-
-        # Load all existing users into memory
-        id_to_user = {}
-        for u in self.db.execute(objects.users.select()):
-            user = objects.User(id=u.id, name=u.name, cookie=u.cookie)
-            self.username_to_user[user.name] = user
-            self.cookie_to_user[user.cookie] = user
-            id_to_user[user.id] = user
-
-        # Next load all existing clusters into memory
-        id_to_cluster = {}
-        for c in self.db.execute(objects.clusters.select()):
-            user = id_to_user[c.user_id]
-            state = json.loads(c.state)
-            cluster = objects.Cluster(
-                id=c.id,
-                name=c.name,
-                user=user,
-                token=c.token,
-                status=c.status,
-                state=state,
-                scheduler_address=c.scheduler_address,
-                dashboard_address=c.dashboard_address,
-                api_address=c.api_address,
-                tls_cert=c.tls_cert,
-                tls_key=c.tls_key,
-            )
-            user.clusters[cluster.name] = cluster
-            self.token_to_cluster[cluster.token] = cluster
-            id_to_cluster[cluster.id] = cluster
-
-        # Next load all existing workers into memory
-        for w in self.db.execute(objects.workers.select()):
-            cluster = id_to_cluster[w.cluster_id]
-            worker = objects.Worker(
-                id=w.id,
-                name=w.name,
-                status=w.status,
-                cluster=cluster,
-                state=json.loads(w.state),
-            )
-            cluster.workers[worker.name] = worker
-            if w.status == WorkerStatus.STARTING:
-                cluster.pending.add(worker.name)
 
     def init_scheduler_proxy(self):
         self.scheduler_proxy = self.scheduler_proxy_class(
@@ -421,84 +369,16 @@ class DaskGateway(Application):
         except KeyboardInterrupt:
             print("\nInterrupted")
 
-    def user_from_cookie(self, cookie):
-        return self.cookie_to_user.get(cookie)
-
-    def get_or_create_user(self, username):
-        user = self.username_to_user.get(username)
-        if user is None:
-            cookie = uuid.uuid4().hex
-            res = self.db.execute(
-                objects.users.insert().values(name=username, cookie=cookie)
-            )
-            user = objects.User(
-                id=res.inserted_primary_key[0], name=username, cookie=cookie
-            )
-            self.cookie_to_user[cookie] = user
-            self.username_to_user[username] = user
-        return user
-
-    def cluster_from_token(self, token):
-        return self.token_to_cluster.get(token)
-
-    def create_cluster(self, user):
-        cluster_name = uuid.uuid4().hex
-        token = uuid.uuid4().hex
-        tls_cert, tls_key = new_keypair(cluster_name)
-
-        res = self.db.execute(
-            objects.clusters.insert().values(
-                name=cluster_name,
-                user_id=user.id,
-                token=token,
-                status=ClusterStatus.STARTING,
-                state=b"{}",
-                scheduler_address="",
-                dashboard_address="",
-                api_address="",
-                tls_cert=tls_cert,
-                tls_key=tls_key,
-            )
-        )
-        cluster = objects.Cluster(
-            id=res.inserted_primary_key[0],
-            name=cluster_name,
-            user=user,
-            token=token,
-            status=ClusterStatus.STARTING,
-            state={},
-            scheduler_address="",
-            dashboard_address="",
-            api_address="",
-            tls_cert=tls_cert,
-            tls_key=tls_key,
-        )
-        user.clusters[cluster_name] = cluster
-        self.token_to_cluster[token] = cluster
-        return cluster
-
     async def _start_cluster(self, cluster):
         self.log.debug("Cluster %s is starting...", cluster.name)
 
         # Walk through the startup process, saving state as updates occur
         async for state in self.cluster_manager.start_cluster(cluster.info):
             self.log.debug("State update for cluster %s", cluster.name)
-            with self.db.begin() as conn:
-                conn.execute(
-                    objects.clusters.update()
-                    .where(objects.clusters.c.id == cluster.id)
-                    .values(state=json.dumps(state).encode("utf-8"))
-                )
-                cluster.state = state
+            self.db.update_cluster(cluster, state=state)
 
         # Move cluster to started
-        with self.db.begin() as conn:
-            conn.execute(
-                objects.clusters.update()
-                .where(objects.clusters.c.id == cluster.id)
-                .values(status=ClusterStatus.STARTED)
-            )
-            cluster.status = ClusterStatus.STARTED
+        self.db.update_cluster(cluster, status=ClusterStatus.STARTED)
 
     async def start_cluster(self, cluster):
         """Start the cluster.
@@ -551,28 +431,21 @@ class DaskGateway(Application):
         await self.scheduler_proxy.add_route("/" + cluster.name, scheduler_address)
 
         # Mark cluster as running
-        with self.db.begin() as conn:
-            conn.execute(
-                objects.clusters.update()
-                .where(objects.clusters.c.id == cluster.id)
-                .values(
-                    scheduler_address=scheduler_address,
-                    dashboard_address=dashboard_address,
-                    api_address=api_address,
-                    status=ClusterStatus.RUNNING,
-                )
-            )
-            cluster.scheduler_address = scheduler_address
-            cluster.dashboard_address = dashboard_address
-            cluster.api_address = api_address
-            cluster.status = ClusterStatus.RUNNING
-
+        self.db.update_cluster(
+            cluster,
+            scheduler_address=scheduler_address,
+            dashboard_address=dashboard_address,
+            api_address=api_address,
+            status=ClusterStatus.RUNNING,
+        )
         return True
 
-    def schedule_start_cluster(self, cluster):
+    def start_new_cluster(self, user):
+        cluster = self.db.create_cluster(user)
         f = self.create_task(self.start_cluster(cluster))
         f.add_done_callback(partial(self._monitor_start_cluster, cluster=cluster))
         cluster._start_future = f
+        return cluster
 
     def _monitor_start_cluster(self, future, cluster=None):
         try:
@@ -596,13 +469,7 @@ class DaskGateway(Application):
         await cancel_task(cluster._start_future)
 
         # Move cluster to stopping
-        with self.db.begin() as conn:
-            conn.execute(
-                objects.clusters.update()
-                .where(objects.clusters.c.id == cluster.id)
-                .values(status=ClusterStatus.STOPPING)
-            )
-            cluster.status = ClusterStatus.STOPPING
+        self.db.update_cluster(cluster, status=ClusterStatus.STOPPING)
 
         # Remove routes from proxies if already set
         await self.web_proxy.delete_route("/gateway/clusters/" + cluster.name)
@@ -618,14 +485,8 @@ class DaskGateway(Application):
 
         # Update the cluster status
         status = ClusterStatus.FAILED if failed else ClusterStatus.STOPPED
-        with self.db.begin() as conn:
-            conn.execute(
-                objects.clusters.update()
-                .where(objects.clusters.c.id == cluster.id)
-                .values(status=status)
-            )
-            cluster.status = status
-            cluster.pending.clear()
+        self.db.update_cluster(cluster, status=status)
+        cluster.pending.clear()
 
         self.log.debug("Cluster %s stopped", cluster.name)
 
@@ -651,33 +512,11 @@ class DaskGateway(Application):
 
     async def scale_up(self, cluster, n_start):
         for _ in range(n_start):
-            w = self.create_worker(cluster)
+            w = self.db.create_worker(cluster)
             w._start_future = self.create_task(self.start_worker(cluster, w))
             w._start_future.add_done_callback(
                 partial(self._monitor_start_worker, worker=w, cluster=cluster)
             )
-
-    def create_worker(self, cluster):
-        worker_name = uuid.uuid4().hex
-
-        res = self.db.execute(
-            objects.workers.insert().values(
-                name=worker_name,
-                cluster_id=cluster.id,
-                status=WorkerStatus.STARTING,
-                state=b"{}",
-            )
-        )
-        worker = objects.Worker(
-            id=res.inserted_primary_key[0],
-            name=worker_name,
-            cluster=cluster,
-            status=WorkerStatus.STARTING,
-            state={},
-        )
-        cluster.pending.add(worker.name)
-        cluster.workers[worker.name] = worker
-        return worker
 
     async def _start_worker(self, cluster, worker):
         self.log.debug("Starting worker %r for cluster %r", worker.name, cluster.name)
@@ -686,22 +525,10 @@ class DaskGateway(Application):
         async for state in self.cluster_manager.start_worker(
             worker.name, cluster.info, cluster.state
         ):
-            with self.db.begin() as conn:
-                conn.execute(
-                    objects.workers.update()
-                    .where(objects.workers.c.id == worker.id)
-                    .values(state=json.dumps(state).encode("utf-8"))
-                )
-                worker.state = state
+            self.db.update_worker(worker, state=state)
 
         # Move worker to started
-        with self.db.begin() as conn:
-            conn.execute(
-                objects.workers.update()
-                .where(objects.workers.c.id == worker.id)
-                .values(status=WorkerStatus.STARTED)
-            )
-            worker.status = WorkerStatus.STARTED
+        self.db.update_worker(worker, status=WorkerStatus.STARTED)
 
     async def start_worker(self, cluster, worker):
         try:
@@ -741,14 +568,8 @@ class DaskGateway(Application):
         self.log.debug("Worker %s connected to cluster %s", worker.name, cluster.name)
 
         # Mark worker as running
-        with self.db.begin() as conn:
-            conn.execute(
-                objects.workers.update()
-                .where(objects.workers.c.id == worker.id)
-                .values(status=WorkerStatus.RUNNING)
-            )
-            cluster.pending.discard(worker.name)
-            worker.status = WorkerStatus.RUNNING
+        self.db.update_worker(worker, status=WorkerStatus.RUNNING)
+        cluster.pending.discard(worker.name)
         return True
 
     def _monitor_start_worker(self, future, worker=None, cluster=None):
@@ -777,14 +598,8 @@ class DaskGateway(Application):
         await cancel_task(worker._start_future)
 
         # Move worker to stopping
-        with self.db.begin() as conn:
-            conn.execute(
-                objects.workers.update()
-                .where(objects.workers.c.id == worker.id)
-                .values(status=WorkerStatus.STOPPING)
-            )
-            cluster.pending.discard(worker.name)
-            worker.status = WorkerStatus.STOPPING
+        self.db.update_worker(worker, status=WorkerStatus.STOPPING)
+        cluster.pending.discard(worker.name)
 
         # Shutdown the worker
         try:
@@ -796,14 +611,7 @@ class DaskGateway(Application):
 
         # Update the worker status
         status = WorkerStatus.FAILED if failed else WorkerStatus.STOPPED
-
-        with self.db.begin() as conn:
-            conn.execute(
-                objects.workers.update()
-                .where(objects.workers.c.id == worker.id)
-                .values(status=status)
-            )
-            worker.status = status
+        self.db.update_worker(worker, status=status)
 
         self.log.debug("Worker %s stopped", worker.name)
 

--- a/dask-gateway-server/dask_gateway_server/objects.py
+++ b/dask-gateway-server/dask_gateway_server/objects.py
@@ -89,7 +89,7 @@ clusters = Table(
 workers = Table(
     "workers",
     metadata,
-    Column("id", Integer, primary_key=True),
+    Column("id", Integer, primary_key=True, autoincrement=True),
     Column("name", Unicode(255), nullable=False),
     Column("cluster_id", ForeignKey("clusters.id", ondelete="CASCADE"), nullable=False),
     Column("status", IntEnum(WorkerStatus), nullable=False),
@@ -149,7 +149,6 @@ class Cluster(object):
         api_address="",
         tls_cert=b"",
         tls_key=b"",
-        active_workers=0,
     ):
         self.id = id
         self.name = name
@@ -162,7 +161,6 @@ class Cluster(object):
         self.api_address = api_address
         self.tls_cert = tls_cert
         self.tls_key = tls_key
-        self.active_workers = active_workers
         self.pending = set()
         self.workers = {}
 
@@ -174,6 +172,10 @@ class Cluster(object):
             # Already running, create finished futures to mark
             self._start_future.set_result(True)
             self._connect_future.set_result(None)
+
+    @property
+    def active_workers(self):
+        return [w for w in self.workers.values() if w.is_active()]
 
     def is_active(self):
         return self.status < ClusterStatus.STOPPING

--- a/dask-gateway-server/dask_gateway_server/objects.py
+++ b/dask-gateway-server/dask_gateway_server/objects.py
@@ -1,5 +1,7 @@
 import asyncio
 import enum
+import json
+import uuid
 
 from sqlalchemy import (
     MetaData,
@@ -13,6 +15,8 @@ from sqlalchemy import (
     create_engine,
 )
 from sqlalchemy.pool import StaticPool
+
+from .tls import new_keypair
 
 
 class _EnumMixin(object):
@@ -58,6 +62,22 @@ class IntEnum(TypeDecorator):
         return self._enumclass(value)
 
 
+class JSON(TypeDecorator):
+    "Represents an immutable structure as a json-encoded string."
+
+    impl = LargeBinary
+
+    def process_bind_param(self, value, dialect):
+        if value is not None:
+            value = json.dumps(value).encode("utf-8")
+        return value
+
+    def process_result_value(self, value, dialect):
+        if value is not None:
+            value = json.loads(value)
+        return value
+
+
 metadata = MetaData()
 
 users = Table(
@@ -77,7 +97,7 @@ clusters = Table(
         "user_id", Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     ),
     Column("status", IntEnum(ClusterStatus), nullable=False),
-    Column("state", LargeBinary, nullable=False),
+    Column("state", JSON, nullable=False),
     Column("token", Unicode(32), nullable=False, unique=True),
     Column("scheduler_address", Unicode(255), nullable=False),
     Column("dashboard_address", Unicode(255), nullable=False),
@@ -93,22 +113,152 @@ workers = Table(
     Column("name", Unicode(255), nullable=False),
     Column("cluster_id", ForeignKey("clusters.id", ondelete="CASCADE"), nullable=False),
     Column("status", IntEnum(WorkerStatus), nullable=False),
-    Column("state", LargeBinary, nullable=False),
+    Column("state", JSON, nullable=False),
 )
 
 
-def make_engine(url="sqlite:///:memory:", **kwargs):
-    if url.startswith("sqlite"):
-        kwargs["connect_args"] = {"check_same_thread": False}
+class DataManager(object):
+    """Holds the internal state for a single Dask Gateway.
 
-    if url.endswith(":memory:"):
-        kwargs["poolclass"] = StaticPool
+    Keeps the memory representation in-sync with the database.
+    """
 
-    engine = create_engine(url, **kwargs)
+    def __init__(self, url="sqlite:///:memory:", **kwargs):
+        if url.startswith("sqlite"):
+            kwargs["connect_args"] = {"check_same_thread": False}
 
-    metadata.create_all(engine)
+        if url.endswith(":memory:"):
+            kwargs["poolclass"] = StaticPool
 
-    return engine
+        engine = create_engine(url, **kwargs)
+
+        metadata.create_all(engine)
+
+        self.db = engine
+
+        self.username_to_user = {}
+        self.cookie_to_user = {}
+        self.token_to_cluster = {}
+
+        # Load state from database
+        self._init_from_database()
+
+    def _init_from_database(self):
+        # Load all existing users into memory
+        id_to_user = {}
+        for u in self.db.execute(users.select()):
+            user = User(id=u.id, name=u.name, cookie=u.cookie)
+            self.username_to_user[user.name] = user
+            self.cookie_to_user[user.cookie] = user
+            id_to_user[user.id] = user
+
+        # Next load all existing clusters into memory
+        id_to_cluster = {}
+        for c in self.db.execute(clusters.select()):
+            user = id_to_user[c.user_id]
+            cluster = Cluster(
+                id=c.id,
+                name=c.name,
+                user=user,
+                token=c.token,
+                status=c.status,
+                state=c.state,
+                scheduler_address=c.scheduler_address,
+                dashboard_address=c.dashboard_address,
+                api_address=c.api_address,
+                tls_cert=c.tls_cert,
+                tls_key=c.tls_key,
+            )
+            user.clusters[cluster.name] = cluster
+            self.token_to_cluster[cluster.token] = cluster
+            id_to_cluster[cluster.id] = cluster
+
+        # Next load all existing workers into memory
+        for w in self.db.execute(workers.select()):
+            cluster = id_to_cluster[w.cluster_id]
+            worker = Worker(
+                id=w.id, name=w.name, status=w.status, cluster=cluster, state=w.state
+            )
+            cluster.workers[worker.name] = worker
+            if w.status == WorkerStatus.STARTING:
+                cluster.pending.add(worker.name)
+
+    def user_from_cookie(self, cookie):
+        """Lookup a user from a cookie"""
+        return self.cookie_to_user.get(cookie)
+
+    def get_or_create_user(self, username):
+        """Lookup a user if they exist, otherwise create a new user"""
+        user = self.username_to_user.get(username)
+        if user is None:
+            cookie = uuid.uuid4().hex
+            res = self.db.execute(users.insert().values(name=username, cookie=cookie))
+            user = User(id=res.inserted_primary_key[0], name=username, cookie=cookie)
+            self.cookie_to_user[cookie] = user
+            self.username_to_user[username] = user
+        return user
+
+    def cluster_from_token(self, token):
+        """Lookup a cluster from a token"""
+        return self.token_to_cluster.get(token)
+
+    def create_cluster(self, user):
+        """Create a new cluster for a user"""
+        cluster_name = uuid.uuid4().hex
+        token = uuid.uuid4().hex
+        tls_cert, tls_key = new_keypair(cluster_name)
+
+        common = {
+            "name": cluster_name,
+            "token": token,
+            "status": ClusterStatus.STARTING,
+            "state": {},
+            "scheduler_address": "",
+            "dashboard_address": "",
+            "api_address": "",
+            "tls_cert": tls_cert,
+            "tls_key": tls_key,
+        }
+
+        with self.db.begin() as conn:
+            res = conn.execute(clusters.insert().values(user_id=user.id, **common))
+            cluster = Cluster(id=res.inserted_primary_key[0], user=user, **common)
+            user.clusters[cluster_name] = cluster
+            self.token_to_cluster[token] = cluster
+
+        return cluster
+
+    def create_worker(self, cluster):
+        """Create a new worker for a cluster"""
+        worker_name = uuid.uuid4().hex
+
+        common = {"name": worker_name, "status": WorkerStatus.STARTING, "state": {}}
+
+        with self.db.begin() as conn:
+            res = conn.execute(workers.insert().values(cluster_id=cluster.id, **common))
+            worker = Worker(id=res.inserted_primary_key[0], cluster=cluster, **common)
+            cluster.pending.add(worker.name)
+            cluster.workers[worker.name] = worker
+
+        return worker
+
+    def update_cluster(self, cluster, **kwargs):
+        """Update a cluster's state"""
+        with self.db.begin() as conn:
+            conn.execute(
+                clusters.update().where(clusters.c.id == cluster.id).values(**kwargs)
+            )
+            for k, v in kwargs.items():
+                setattr(cluster, k, v)
+
+    def update_worker(self, worker, **kwargs):
+        """Update a worker's state"""
+        with self.db.begin() as conn:
+            conn.execute(
+                workers.update().where(workers.c.id == worker.id).values(**kwargs)
+            )
+            for k, v in kwargs.items():
+                setattr(worker, k, v)
 
 
 class User(object):

--- a/dask-gateway/dask_gateway/dask_cli.py
+++ b/dask-gateway/dask_gateway/dask_cli.py
@@ -13,7 +13,8 @@ from tornado.ioloop import IOLoop, TimeoutError
 from distributed import Scheduler, Worker, Nanny
 from distributed.security import Security
 from distributed.utils import ignoring
-from distributed.cli.utils import install_signal_handlers, uri_from_host_port
+from distributed.cli.utils import install_signal_handlers
+
 from distributed.proctitle import (
     enable_proctitle_on_children,
     enable_proctitle_on_current,
@@ -275,10 +276,9 @@ async def start_scheduler(gateway, security, exit_on_failure=True):
         services[("bokeh", 0)] = (BokehScheduler, {})
         bokeh = True
 
-    addr = uri_from_host_port("tls://", None, 0)
     scheduler = Scheduler(loop=loop, services=services, security=security)
     scheduler.add_plugin(plugin)
-    scheduler.start(addr)
+    scheduler.start("tls://")
 
     host = urlparse(scheduler.address).hostname
     gateway_port = scheduler.services["gateway"].port


### PR DESCRIPTION
- Extract state handling out of gateway class
- Remove `active_workers` counter, can be computed quickly and was hard to keep in sync
- Don't generate worker id's in the gateway, let the database do that