### PR TITLE
Cleanup clusters on shutdown

### DIFF
--- a/dask-gateway-server/dask_gateway_server/objects.py
+++ b/dask-gateway-server/dask_gateway_server/objects.py
@@ -202,6 +202,12 @@ class DataManager(object):
         """Lookup a cluster from a token"""
         return self.token_to_cluster.get(token)
 
+    def active_clusters(self):
+        for user in self.username_to_user.values():
+            for cluster in user.clusters.values():
+                if cluster.is_active():
+                    yield cluster
+
     def create_cluster(self, user):
         """Create a new cluster for a user"""
         cluster_name = uuid.uuid4().hex


### PR DESCRIPTION
Register signal handlers to cleanup all active clusters on
SIGINT/SIGTERM. This behavior can be turned off by setting

```python
c.DaskGateway.stop_clusters_on_shutdown = False
```