### PR TITLE
Check gateway state upon restart

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,12 +34,15 @@ _PIDS = set()
 def cleanup_lost_processes():
     if not _PIDS:
         return
+    nkilled = 0
     for pid in _PIDS:
         try:
             os.kill(pid, signal.SIGTERM)
+            nkilled += 1
         except OSError:
             pass
-    print("-- Stopped %d lost processes --" % len(_PIDS))
+    if nkilled:
+        print("-- Stopped %d lost processes --" % nkilled)
 
 
 class LocalTestingClusterManager(UnsafeLocalClusterManager):


### PR DESCRIPTION
When restarting a gateway process, we check the status of previously
active clusters. Workers/clusters that have failed during the gateway
downtime are marked as failed and are appropriately cleaned up. The
gateway state is then updated to match that of all remaining clusters.