### PR TITLE
Add configuration to dask client

### DIFF
--- a/dask-gateway/MANIFEST.in
+++ b/dask-gateway/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include dask_gateway *.py
+recursive-include dask_gateway *.yaml
 
 include versioneer.py
 include setup.py

--- a/dask-gateway/dask_gateway/__init__.py
+++ b/dask-gateway/dask_gateway/__init__.py
@@ -1,6 +1,11 @@
 from .client import Gateway, DaskGatewayCluster
 from .auth import KerberosAuth, BasicAuth
 
+# Load configuration
+from . import config
+
+del config
+
 from ._version import get_versions
 
 __version__ = get_versions()["version"]

--- a/dask-gateway/dask_gateway/config.py
+++ b/dask-gateway/dask_gateway/config.py
@@ -1,0 +1,15 @@
+from __future__ import print_function, division, absolute_import
+
+import os
+
+import dask
+import yaml
+
+
+fn = os.path.join(os.path.dirname(__file__), "gateway.yaml")
+dask.config.ensure_file(source=fn)
+
+with open(fn) as f:
+    defaults = yaml.safe_load(f)
+
+dask.config.update_defaults(defaults)

--- a/dask-gateway/dask_gateway/gateway.yaml
+++ b/dask-gateway/dask_gateway/gateway.yaml
@@ -1,0 +1,9 @@
+gateway:
+  address: null     # The full address to the dask-gateway server
+
+  auth:
+    type: basic     # The authentication type to use. Options are basic,
+                    # kerberos, or a full class path to a custom class.
+
+    kwargs: {}      # Keyword arguments to use when instantiating the
+                    # authentication class above.

--- a/dask-gateway/setup.py
+++ b/dask-gateway/setup.py
@@ -19,7 +19,8 @@ setup(
         open("README.rst").read() if os.path.exists("README.rst") else ""
     ),
     url="http://github.com/jcrist/dask-gateway/",
-    packages=["dask_gateway", "dask_gateway"],
+    packages=["dask_gateway"],
+    package_data={"dask_gateway": ["*.yaml"]},
     install_requires=install_requires,
     extras_require=extras_require,
     entry_points={

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,84 @@
+import pytest
+
+import dask
+from dask_gateway.auth import get_auth, BasicAuth, KerberosAuth
+from dask_gateway.client import Gateway
+
+
+def test_get_auth():
+    # Pass through existing auth objects
+    auth = BasicAuth()
+    assert get_auth(auth) is auth
+
+    # Auth by keyword name
+    auth = get_auth("basic")
+    assert isinstance(auth, BasicAuth)
+
+    auth = get_auth("kerberos")
+    assert isinstance(auth, KerberosAuth)
+
+    # Auth from config
+    config = {"gateway": {"auth": {"type": "basic", "kwargs": {}}}}
+    with dask.config.set(config):
+        auth = get_auth()
+        assert isinstance(auth, BasicAuth)
+
+    # Auth from config with import path
+    config = {
+        "gateway": {"auth": {"type": "dask_gateway.auth.BasicAuth", "kwargs": {}}}
+    }
+    with dask.config.set(config):
+        auth = get_auth()
+        assert isinstance(auth, BasicAuth)
+
+    # Auth from config with kwargs
+    config = {"gateway": {"auth": {"type": "basic", "kwargs": {"username": "bruce"}}}}
+    with dask.config.set(config):
+        auth = get_auth()
+        assert isinstance(auth, BasicAuth)
+        assert auth.username == "bruce"
+
+    # Errors
+    with pytest.raises(TypeError):
+        get_auth(1)
+
+    with pytest.raises(TypeError):
+        get_auth(lambda: 1)
+
+    with pytest.raises(ImportError):
+        get_auth("dask_gateway.auth.Foo")
+
+    with pytest.raises(ImportError):
+        get_auth("not_a_real_module_name_foo_barrr")
+
+
+def test_client_init():
+    config = {
+        "gateway": {
+            "address": "http://127.0.0.1:8888",
+            "auth": {"type": "basic", "kwargs": {"username": "bruce"}},
+        }
+    }
+
+    with dask.config.set(config):
+        # Defaults
+        gateway = Gateway()
+        assert gateway.address == "http://127.0.0.1:8888"
+        assert gateway._auth.username == "bruce"
+
+        # Address override
+        gateway = Gateway(address="http://127.0.0.1:9999")
+        assert gateway.address == "http://127.0.0.1:9999"
+        assert gateway._auth.username == "bruce"
+
+        # Auth override
+        gateway = Gateway(auth="kerberos")
+        assert gateway.address == "http://127.0.0.1:8888"
+        assert isinstance(gateway._auth, KerberosAuth)
+
+    config = {"gateway": {"address": None, "auth": {"type": "basic", "kwargs": {}}}}
+
+    with dask.config.set(config):
+        # No address provided
+        with pytest.raises(ValueError):
+            gateway = Gateway()


### PR DESCRIPTION
Add config file and configuration lookup to client ``dask_gateway``
library. This makes use of the standard yaml dask configuration
infrastructure, and so far allows configuring the gateway address and
auth.