### PR TITLE
Add support for externally managed proxies

### DIFF
--- a/dask-gateway-server/dask-gateway-proxy/logging.go
+++ b/dask-gateway-server/dask-gateway-proxy/logging.go
@@ -35,29 +35,30 @@ func ParseLevel(s string) LogLevel {
 	panic("Couldn't parse log level " + s)
 }
 
-func (l LogLevel) String() string {
+func (l LogLevel) Char() byte {
 	switch l {
 	case ERROR:
-		return "ERROR"
+		return 'E'
 	case WARN:
-		return "WARN"
+		return 'W'
 	case INFO:
-		return "INFO"
+		return 'I'
 	case DEBUG:
-		return "DEBUG"
+		return 'D'
 	}
-	return "<unknown>"
+	return '?'
 }
 
 type Logger struct {
 	sync.Mutex
+	name  string
 	level LogLevel
 	out   io.Writer
 	buf   []byte
 }
 
-func NewLogger(level LogLevel) *Logger {
-	return &Logger{level: level, out: os.Stderr}
+func NewLogger(name string, level LogLevel) *Logger {
+	return &Logger{name: name, level: level, out: os.Stderr}
 }
 
 func (l *Logger) logMsg(level LogLevel, msg string) {
@@ -66,11 +67,13 @@ func (l *Logger) logMsg(level LogLevel, msg string) {
 		l.Lock()
 		defer l.Unlock()
 		l.buf = l.buf[:0]
-		l.buf = append(l.buf, "[dask-gateway-proxy] "...)
-		l.buf = now.AppendFormat(l.buf, "2006-01-02 15:04:05")
+		l.buf = append(l.buf, '[')
+		l.buf = append(l.buf, level.Char())
 		l.buf = append(l.buf, ' ')
-		l.buf = append(l.buf, level.String()...)
-		l.buf = append(l.buf, ": "...)
+		l.buf = now.AppendFormat(l.buf, "2006-01-02 15:04:05.000")
+		l.buf = append(l.buf, ' ')
+		l.buf = append(l.buf, l.name...)
+		l.buf = append(l.buf, "] "...)
 		l.buf = append(l.buf, msg...)
 		l.buf = append(l.buf, '\n')
 		l.out.Write(l.buf)

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -198,7 +198,10 @@ class Gateway(object):
             self._loop_runner.stop()
 
     def __del__(self):
-        self.close()
+        # __del__ is still called, even if __init__ failed. Only close if init
+        # actually succeeded.
+        if hasattr(self, "_started"):
+            self.close()
 
     def __enter__(self):
         return self

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,11 +3,12 @@ import pytest
 
 from dask_gateway_server import __version__ as VERSION
 from dask_gateway_server.app import DaskGateway
+from dask_gateway_server.proxy.core import SchedulerProxyApp, WebProxyApp, _PROXY_EXE
 from dask_gateway.dask_cli import worker, scheduler
 
 
 def test_generate_config(tmpdir, capfd):
-    cfg_file = str(tmpdir.join("jupyterhub_config.py"))
+    cfg_file = str(tmpdir.join("dask_gateway_config.py"))
     orig_text = "c.foo = 'bar'"
 
     with open(cfg_file, "w") as f:
@@ -37,6 +38,57 @@ def test_generate_config(tmpdir, capfd):
 
     assert "DaskGateway.cluster_manager_class" in cfg_text
     assert "ClusterManager.worker_connect_timeout" in cfg_text
+
+
+@pytest.mark.parametrize("kind", ["web", "scheduler"])
+def test_proxy_cli(kind, tmpdir, monkeypatch):
+    cfg_file = str(tmpdir.join("dask_gateway_config.py"))
+
+    text = (
+        "c.DaskGateway.gateway_url = 'tls://127.0.0.1:8786'\n"
+        "c.DaskGateway.public_url = 'http://127.0.0.1:8888'\n"
+        "c.SchedulerProxy.api_url = 'http://127.0.0.1:8866'\n"
+        "c.WebProxy.api_url = 'http://127.0.0.1:8867'\n"
+        "c.ProxyBase.log_level = 'debug'\n"
+        "c.ProxyBase.auth_token = 'abcde'"
+    )
+    with open(cfg_file, "w") as f:
+        f.write(text)
+
+    if kind == "web":
+        address = "127.0.0.1:8888"
+        api_address = "127.0.0.1:8867"
+    else:
+        address = "127.0.0.1:8786"
+        api_address = "127.0.0.1:8866"
+
+    called_with = []
+
+    def mock_execle(*args):
+        called_with.extend(args)
+
+    monkeypatch.setattr(os, "execle", mock_execle)
+    DaskGateway.launch_instance([kind + "-proxy", "-f", cfg_file])
+    DaskGateway.clear_instance()
+    SchedulerProxyApp.clear_instance()
+    WebProxyApp.clear_instance()
+
+    assert called_with
+    env = called_with.pop()
+
+    assert called_with == [
+        _PROXY_EXE,
+        "dask-gateway-proxy",
+        kind,
+        "-address",
+        address,
+        "-api-address",
+        api_address,
+        "-log-level",
+        "debug",
+    ]
+
+    assert "DASK_GATEWAY_PROXY_TOKEN" in env
 
 
 @pytest.mark.parametrize("cmd", [scheduler, worker])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -81,4 +81,4 @@ def test_client_init():
     with dask.config.set(config):
         # No address provided
         with pytest.raises(ValueError):
-            gateway = Gateway()
+            Gateway()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -376,6 +376,7 @@ async def test_gateway_resume_clusters_after_shutdown(tmpdir):
         gateway_url=gateway_proc.gateway_url,
         private_url=gateway_proc.private_url,
         public_url=gateway_proc.public_url,
+        check_cluster_timeout=2,
     ) as gateway_proc:
 
         active_clusters = list(gateway_proc.db.active_clusters())


### PR DESCRIPTION
Adds the following features:
- CLI commands for starting the scheduler and web proxy, optionally
loading values from config file.
- Ability to have proxies started/stopped external to the gateway.
- Logging for the proxies matches the default format of the gateway.
- A few test cleanups