### PR TITLE
Rename gateway CLI

### DIFF
--- a/dask-gateway-server/dask_gateway_server/app.py
+++ b/dask-gateway-server/dask_gateway_server/app.py
@@ -45,13 +45,13 @@ Application.log_format.default_value = (
 class GenerateConfig(Application):
     """Generate and write a default configuration file"""
 
-    name = "dask-gateway generate-config"
+    name = "dask-gateway-server generate-config"
     version = VERSION
     description = "Generate and write a default configuration file"
 
     examples = """
 
-        dask-gateway generate-config
+        dask-gateway-server generate-config
     """
 
     output = Unicode(
@@ -90,7 +90,7 @@ class GenerateConfig(Application):
 class DaskGateway(Application):
     """A gateway for managing dask clusters across multiple users"""
 
-    name = "dask-gateway"
+    name = "dask-gateway-server"
     version = VERSION
 
     description = """Start a Dask Gateway server"""
@@ -99,7 +99,7 @@ class DaskGateway(Application):
 
     Start the server on 10.0.1.2:8080:
 
-        dask-gateway --public-url 10.0.1.2:8080
+        dask-gateway-server --public-url 10.0.1.2:8080
     """
 
     subcommands = {

--- a/dask-gateway-server/dask_gateway_server/proxy/core.py
+++ b/dask-gateway-server/dask_gateway_server/proxy/core.py
@@ -305,12 +305,12 @@ class ProxyApp(Application):
 class SchedulerProxyApp(ProxyApp):
     """Start the scheduler proxy"""
 
-    name = "dask-gateway scheduler-proxy"
+    name = "dask-gateway-server scheduler-proxy"
     description = "Start the scheduler proxy"
 
     examples = """
 
-        dask-gateway scheduler-proxy
+        dask-gateway-server scheduler-proxy
     """
 
     def make_proxy(self):
@@ -322,12 +322,12 @@ class SchedulerProxyApp(ProxyApp):
 class WebProxyApp(ProxyApp):
     """Start the web proxy"""
 
-    name = "dask-gateway scheduler-proxy"
+    name = "dask-gateway-server scheduler-proxy"
     description = "Start the web proxy"
 
     examples = """
 
-        dask-gateway web-proxy
+        dask-gateway-server web-proxy
     """
 
     def make_proxy(self):

--- a/dask-gateway-server/setup.py
+++ b/dask-gateway-server/setup.py
@@ -113,6 +113,8 @@ setup(
     package_data={"dask_gateway_server": ["proxy/dask-gateway-proxy"]},
     install_requires=install_requires,
     extras_require=extras_require,
-    entry_points={"console_scripts": ["dask-gateway = dask_gateway_server.app:main"]},
+    entry_points={
+        "console_scripts": ["dask-gateway-server = dask_gateway_server.app:main"]
+    },
     zip_safe=False,
 )

--- a/demo/dask_gateway_config.py
+++ b/demo/dask_gateway_config.py
@@ -6,8 +6,16 @@ c.DaskGateway.private_url = "http://127.0.0.1:8081"
 # Set the database location
 c.DaskGateway.db_url = "sqlite:////var/dask-gateway/dask_gateway.sqlite"
 
+# Set the encryption keys for the database. These should be randomly generated,
+# and probably set via the DASK_GATEWAY_ENCRYPT_KEYS environment variable
+# instead of stored in plaintext in the config.
+c.DaskGateway.db_encrypt_keys = [
+    b"z+hBxgauqbndqCZSqJMsKYI7FDMth6YYGqwnx7Ssqvg=",
+    b"2Ai+D94CX/47LiRv3TLWV+K18TQ3fB1nTz18zmALbc8=",
+]
+
 # Run the proxies separately from the gateway. The auth_tokens here should be
-# randomly generated, and probably stored set via the DASK_GATEWAY_PROXY_TOKEN
+# randomly generated, and probably set via the DASK_GATEWAY_PROXY_TOKEN
 # environment variable instead of stored in plaintext in the config.
 c.WebProxy.auth_token = "supersecret"
 c.WebProxy.externally_managed = True

--- a/demo/files/etc/supervisord.d/dask_gateway.conf
+++ b/demo/files/etc/supervisord.d/dask_gateway.conf
@@ -1,5 +1,5 @@
 [program:dask-gateway]
-command=/opt/miniconda/bin/dask-gateway -f /working/demo/dask_gateway_config.py
+command=/opt/miniconda/bin/dask-gateway-server -f /working/demo/dask_gateway_config.py
 startsecs=2
 stopwaitsecs=10
 user=dask
@@ -10,7 +10,7 @@ autostart=true
 autorestart=false
 
 [program:dask-gateway-scheduler-proxy]
-command=/opt/miniconda/bin/dask-gateway scheduler-proxy -f /working/demo/dask_gateway_config.py
+command=/opt/miniconda/bin/dask-gateway-server scheduler-proxy -f /working/demo/dask_gateway_config.py
 startsecs=2
 stopwaitsecs=10
 user=dask
@@ -21,7 +21,7 @@ autostart=true
 autorestart=false
 
 [program:dask-gateway-web-proxy]
-command=/opt/miniconda/bin/dask-gateway web-proxy -f /working/demo/dask_gateway_config.py
+command=/opt/miniconda/bin/dask-gateway-server web-proxy -f /working/demo/dask_gateway_config.py
 startsecs=2
 stopwaitsecs=10
 user=dask


### PR DESCRIPTION
Rename `dask-gateway` CLI to `dask-gateway-server`. This better matches
the package name it comes from, and doesn't prevent the creation of a
`dask-gateway` client CLI down the road.