### PR TITLE
Move cluster managers into sub-module

### DIFF
--- a/dask-gateway-server/dask_gateway_server/app.py
+++ b/dask-gateway-server/dask_gateway_server/app.py
@@ -20,7 +20,7 @@ from traitlets.config import Application, catch_config_error
 
 from . import __version__ as VERSION
 from . import handlers
-from .cluster import ClusterManager
+from .managers import ClusterManager
 from .auth import Authenticator
 from .objects import (
     DataManager,
@@ -144,8 +144,8 @@ class DaskGateway(Application):
     )
 
     cluster_manager_class = Type(
-        "dask_gateway_server.local_cluster.LocalClusterManager",
-        klass="dask_gateway_server.cluster.ClusterManager",
+        "dask_gateway_server.managers.local.LocalClusterManager",
+        klass="dask_gateway_server.managers.ClusterManager",
         help="The gateway cluster manager class to use",
         config=True,
     )

--- a/dask-gateway-server/dask_gateway_server/managers/__init__.py
+++ b/dask-gateway-server/dask_gateway_server/managers/__init__.py
@@ -1,0 +1,1 @@
+from .base import ClusterManager

--- a/dask-gateway-server/dask_gateway_server/managers/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/base.py
@@ -1,7 +1,7 @@
 from traitlets import Unicode, Float, Integer, Dict, Bool
 from traitlets.config import LoggingConfigurable
 
-from .utils import MemoryLimit
+from ..utils import MemoryLimit
 
 
 class ClusterManager(LoggingConfigurable):

--- a/dask-gateway-server/dask_gateway_server/managers/local.py
+++ b/dask-gateway-server/dask_gateway_server/managers/local.py
@@ -8,7 +8,7 @@ import sys
 
 from traitlets import List, Unicode, Integer, default
 
-from .cluster import ClusterManager
+from .base import ClusterManager
 
 
 __all__ = ("LocalClusterManager", "UnsafeLocalClusterManager")

--- a/dask-gateway-server/dask_gateway_server/managers/yarn.py
+++ b/dask-gateway-server/dask_gateway_server/managers/yarn.py
@@ -5,7 +5,7 @@ import skein
 from tornado import gen
 from traitlets import Unicode, Dict, Instance, default
 
-from .cluster import ClusterManager
+from .base import ClusterManager
 
 
 class YarnClusterManager(ClusterManager):

--- a/dask-gateway-server/setup.py
+++ b/dask-gateway-server/setup.py
@@ -109,7 +109,11 @@ setup(
         open("README.rst").read() if os.path.exists("README.rst") else ""
     ),
     url="http://github.com/jcrist/dask-gateway/",
-    packages=["dask_gateway_server", "dask_gateway_server.proxy"],
+    packages=[
+        "dask_gateway_server",
+        "dask_gateway_server.proxy",
+        "dask_gateway_server.managers",
+    ],
     package_data={"dask_gateway_server": ["proxy/dask-gateway-proxy"]},
     install_requires=install_requires,
     extras_require=extras_require,

--- a/demo/dask_gateway_config.py
+++ b/demo/dask_gateway_config.py
@@ -32,7 +32,7 @@ c.DaskGateway.authenticator_class = "dask_gateway_server.auth.DummyAuthenticator
 
 # Configure the gateway to use YARN as the cluster manager
 c.DaskGateway.cluster_manager_class = (
-    "dask_gateway_server.yarn_cluster.YarnClusterManager"
+    "dask_gateway_server.managers.yarn.YarnClusterManager"
 )
 
 c.YarnClusterManager.scheduler_cmd = "/opt/miniconda/bin/dask-gateway-scheduler"

--- a/docs/source/api-server.rst
+++ b/docs/source/api-server.rst
@@ -41,12 +41,12 @@ Cluster Managers
 Local Processes
 ^^^^^^^^^^^^^^^
 
-.. autoconfigurable:: dask_gateway_server.local_cluster.LocalClusterManager
+.. autoconfigurable:: dask_gateway_server.managers.local.LocalClusterManager
 
-.. autoconfigurable:: dask_gateway_server.local_cluster.UnsafeLocalClusterManager
+.. autoconfigurable:: dask_gateway_server.managers.local.UnsafeLocalClusterManager
 
 
 YARN
 ^^^^
 
-.. autoconfigurable:: dask_gateway_server.yarn_cluster.YarnClusterManager
+.. autoconfigurable:: dask_gateway_server.managers.yarn.YarnClusterManager

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -7,7 +7,7 @@ from cryptography.fernet import Fernet
 
 from dask_gateway import Gateway
 from dask_gateway_server.app import DaskGateway
-from dask_gateway_server.cluster import ClusterManager
+from dask_gateway_server.managers import ClusterManager
 from dask_gateway_server.utils import random_port
 
 from .utils import InProcessClusterManager, LocalTestingClusterManager, temp_gateway

--- a/tests/test_local_cluster.py
+++ b/tests/test_local_cluster.py
@@ -1,4 +1,4 @@
-from dask_gateway_server.local_cluster import is_running
+from dask_gateway_server.managers.local import is_running
 
 from .utils import ClusterManagerTests, LocalTestingClusterManager
 

--- a/tests/test_yarn_cluster.py
+++ b/tests/test_yarn_cluster.py
@@ -6,7 +6,7 @@ skein = pytest.importorskip("skein")
 if not os.environ.get("TEST_DASK_GATEWAY_YARN"):
     pytest.skip("Not running YARN tests", allow_module_level=True)
 
-from dask_gateway_server.yarn_cluster import YarnClusterManager
+from dask_gateway_server.managers.yarn import YarnClusterManager
 
 from .utils import ClusterManagerTests
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,7 +26,7 @@ from dask_gateway_server.objects import (
     ClusterStatus,
     WorkerStatus,
 )
-from dask_gateway_server.local_cluster import UnsafeLocalClusterManager
+from dask_gateway_server.managers.local import UnsafeLocalClusterManager
 
 
 _PIDS = set()


### PR DESCRIPTION
Reorganizes the cluster managers into a sub-module ``dask_gateway_server.managers``.