### PR TITLE
Add support for PBS clusters

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 omit =
     tests/*.py
     */_version.py
+    dask-gateway-server/dask_gateway_server/managers/jobqueue/launcher.py
 source = 
     dask-gateway-server/dask_gateway_server
     dask-gateway/dask_gateway

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,18 @@ jobs:
           script:
             - docker exec master /working/continuous_integration/docker/hadoop/script.sh
 
+        - if: (commit_message !~ skip-tests) AND (commit_message ~= test-pbs)
+          env:
+            - PBS-TESTS=true
+          services:
+            - docker
+          before_install:
+            - ./continuous_integration/docker/pbs/start.sh
+          install:
+            - docker exec pbs /working/continuous_integration/docker/pbs/install.sh
+          script:
+            - docker exec -u dask pbs /working/continuous_integration/docker/pbs/script.sh
+
         - env:
             - DOCS=true
           before_install:

--- a/continuous_integration/docker/pbs/Dockerfile
+++ b/continuous_integration/docker/pbs/Dockerfile
@@ -15,11 +15,28 @@ RUN yum install -y bzip2 \
     && yum clean all \
     && rm -rf /var/cache/yum
 
+# Install go
+RUN curl https://dl.google.com/go/go1.12.2.linux-amd64.tar.gz -o /tmp/go.tar.gz \
+    && tar -xzf /tmp/go.tar.gz -C /opt/ \
+    && rm /tmp/go.tar.gz
+
+# Make a few user accounts, and configure their bashrc files
+RUN useradd -m dask \
+    && useradd -m alice \
+    && useradd -m bob \
+    && groupadd dask_users \
+    && usermod -a -G dask_users alice \
+    && usermod -a -G dask_users bob \
+    && echo 'export PATH="/opt/go/bin:/opt/miniconda/bin:$PATH"' >> ~/.bashrc \
+    && echo 'export PATH="/opt/miniconda/bin:$PATH"' >> /home/dask/.bashrc \
+    && echo 'export PATH="/opt/miniconda/bin:$PATH"' >> /home/alice/.bashrc \
+    && echo 'export PATH="/opt/miniconda/bin:$PATH"' >> /home/bob/.bashrc
+
 # Install pbspro
 RUN yum install -y unzip \
     && curl -L -o /tmp/pbspro.zip https://github.com/PBSPro/pbspro/releases/download/v18.1.4/pbspro_1.8.4.centos7.zip \
     && unzip /tmp/pbspro.zip -d /tmp/pbspro \
-    && yum install -y /tmp/pbspro/pbspro*/pbspro-server-*.rpm \
+    && yum install -y sudo /tmp/pbspro/pbspro*/pbspro-server-*.rpm \
     && yum remove -y unzip \
     && yum clean all \
     && rm -rf /var/cache/yum
@@ -27,10 +44,6 @@ RUN yum install -y unzip \
 # Notify dask-gateway tests that PBS is available
 ENV TEST_DASK_GATEWAY_PBS true
 ENV PBS_MASTER pbs_master
-
-# Make a few user accounts
-RUN useradd -m alice
-RUN useradd -m bob
 
 # Copy over files
 COPY ./files /

--- a/continuous_integration/docker/pbs/files/etc/sudoers.d/dask
+++ b/continuous_integration/docker/pbs/files/etc/sudoers.d/dask
@@ -1,0 +1,4 @@
+Cmnd_Alias DASK_GATEWAY_JOBQUEUE_LAUNCHER = /opt/miniconda/bin/dask-gateway-jobqueue-launcher
+
+%dask_users ALL=(dask) /usr/bin/sudo
+dask ALL=(%dask_users) NOPASSWD:DASK_GATEWAY_JOBQUEUE_LAUNCHER

--- a/continuous_integration/docker/pbs/files/root/start.sh
+++ b/continuous_integration/docker/pbs/files/root/start.sh
@@ -6,8 +6,9 @@ HOSTNAME=$(hostname)
 
 # Configure PBS to run all on one node
 sed -i "s/PBS_SERVER=.*/PBS_SERVER=$HOSTNAME/" $PBS_CONF_FILE
-sed -i "s/\$clienthost .*/\$clienthost $HOSTNAME/" $MOM_CONF_FILE
 sed -i "s/PBS_START_MOM=.*/PBS_START_MOM=1/" $PBS_CONF_FILE
+sed -i "s/\$clienthost .*/\$clienthost $HOSTNAME/" $MOM_CONF_FILE
+echo "\$usecp *:/ /" >> $MOM_CONF_FILE
 
 # Start PBS
 /etc/init.d/pbs start

--- a/continuous_integration/docker/pbs/files/root/start.sh
+++ b/continuous_integration/docker/pbs/files/root/start.sh
@@ -18,5 +18,6 @@ echo "\$usecp *:/ /" >> $MOM_CONF_FILE
 /opt/pbs/bin/qmgr -c "set server job_history_enable = True"
 /opt/pbs/bin/qmgr -c "set server job_history_duration = 24:00:00"
 /opt/pbs/bin/qmgr -c "set node pbs queue=workq"
+/opt/pbs/bin/qmgr -c "set server operators += dask@pbs"
 
 sleep infinity

--- a/continuous_integration/docker/pbs/install.sh
+++ b/continuous_integration/docker/pbs/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+source ~/.bashrc
+
+set -xe
+
+cd /working
+
+conda install psutil
+
+pip install \
+    dask \
+    distributed \
+    cryptography \
+    tornado \
+    traitlets \
+    sqlalchemy \
+    pytest \
+    pytest-asyncio
+
+pushd dask-gateway
+python setup.py develop
+popd
+
+pushd dask-gateway-server
+python setup.py develop
+popd
+
+pip list

--- a/continuous_integration/docker/pbs/script.sh
+++ b/continuous_integration/docker/pbs/script.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+source ~/.bashrc
+
+set -xe
+
+cd /working
+
+py.test tests/test_pbs_cluster.py -v

--- a/dask-gateway-server/dask_gateway_server/app.py
+++ b/dask-gateway-server/dask_gateway_server/app.py
@@ -31,7 +31,7 @@ from .objects import (
     is_in_memory_db,
 )
 from .proxy import SchedulerProxy, WebProxy
-from .utils import cleanup_tmpdir, cancel_task
+from .utils import cleanup_tmpdir, cancel_task, TaskPool
 
 
 # Override default values for logging
@@ -367,16 +367,6 @@ class DaskGateway(Application):
     def public_url_prefix(self):
         return urlparse(self.public_url).path
 
-    def create_task(self, task):
-        out = asyncio.ensure_future(task)
-        self.pending_tasks.add(out)
-        return out
-
-    def create_background_task(self, task):
-        out = asyncio.ensure_future(task)
-        self.background_tasks.add(out)
-        return out
-
     @catch_config_error
     def initialize(self, argv=None):
         super().initialize(argv)
@@ -385,6 +375,7 @@ class DaskGateway(Application):
         self.load_config_file(self.config_file)
         self.init_logging()
         self.init_tempdir()
+        self.init_asyncio()
         self.init_scheduler_proxy()
         self.init_web_proxy()
         self.init_cluster_manager()
@@ -421,6 +412,9 @@ class DaskGateway(Application):
             os.mkdir(self.temp_dir, mode=0o700)
             weakref.finalize(self, cleanup_tmpdir, self.log, self.temp_dir)
 
+    def init_asyncio(self):
+        self.task_pool = TaskPool()
+
     def init_scheduler_proxy(self):
         self.scheduler_proxy = self.scheduler_proxy_class(
             parent=self, log=self.log, public_url=self.gateway_url
@@ -437,7 +431,11 @@ class DaskGateway(Application):
 
     def init_cluster_manager(self):
         self.cluster_manager = self.cluster_manager_class(
-            parent=self, log=self.log, temp_dir=self.temp_dir, api_url=self.api_url
+            parent=self,
+            log=self.log,
+            task_pool=self.task_pool,
+            temp_dir=self.temp_dir,
+            api_url=self.api_url,
         )
 
     def init_authenticator(self):
@@ -458,8 +456,6 @@ class DaskGateway(Application):
             cookie_secret=self.cookie_secret,
             cookie_max_age_days=self.cookie_max_age_days,
         )
-        self.pending_tasks = weakref.WeakSet()
-        self.background_tasks = weakref.WeakSet()
 
     async def start_async(self):
         self.init_signal()
@@ -502,7 +498,7 @@ class DaskGateway(Application):
                 n_clusters,
             )
 
-        self.create_background_task(self.cleanup_database())
+        self.task_pool.create_background_task(self.cleanup_database())
 
     async def cleanup_database(self):
         while True:
@@ -603,11 +599,6 @@ class DaskGateway(Application):
         if hasattr(self, "http_server"):
             self.http_server.stop()
 
-        # Stop any background tasks
-        if hasattr(self, "background_tasks"):
-            for task in self.background_tasks:
-                task.cancel()
-
         # If requested, shutdown any active clusters
         if self.stop_clusters_on_shutdown:
             tasks = {
@@ -631,17 +622,8 @@ class DaskGateway(Application):
         else:
             self.log.info("Leaving any active clusters running")
 
-        # Wait for a short period for any ongoing tasks to complete, before
-        # canceling them
-        try:
-            await asyncio.wait_for(
-                asyncio.gather(
-                    *getattr(self, "pending_tasks", ()), return_exceptions=True
-                ),
-                timeout,
-            )
-        except (asyncio.TimeoutError, asyncio.CancelledError):
-            pass
+        if hasattr(self, "task_pool"):
+            await self.task_pool.close(timeout=timeout)
 
         # Shutdown the proxies
         if hasattr(self, "scheduler_proxy"):
@@ -739,7 +721,7 @@ class DaskGateway(Application):
 
     def start_new_cluster(self, user):
         cluster = self.db.create_cluster(user)
-        f = self.create_task(self.start_cluster(cluster))
+        f = self.task_pool.create_task(self.start_cluster(cluster))
         f.add_done_callback(partial(self._monitor_start_cluster, cluster=cluster))
         cluster._start_future = f
         return cluster
@@ -788,7 +770,7 @@ class DaskGateway(Application):
         self.log.debug("Cluster %s stopped", cluster.name)
 
     def schedule_stop_cluster(self, cluster, failed=False):
-        self.create_task(self.stop_cluster(cluster, failed=failed))
+        self.task_pool.create_task(self.stop_cluster(cluster, failed=failed))
 
     async def scale(self, cluster, total):
         """Scale cluster to total workers"""
@@ -810,7 +792,7 @@ class DaskGateway(Application):
     async def scale_up(self, cluster, n_start):
         for _ in range(n_start):
             w = self.db.create_worker(cluster)
-            w._start_future = self.create_task(self.start_worker(cluster, w))
+            w._start_future = self.task_pool.create_task(self.start_worker(cluster, w))
             w._start_future.add_done_callback(
                 partial(self._monitor_start_worker, worker=w, cluster=cluster)
             )
@@ -918,7 +900,7 @@ class DaskGateway(Application):
         self.log.debug("Worker %s stopped", worker.name)
 
     def schedule_stop_worker(self, cluster, worker, failed=False):
-        self.create_task(self.stop_worker(cluster, worker, failed=failed))
+        self.task_pool.create_task(self.stop_worker(cluster, worker, failed=failed))
 
     def maybe_fail_worker(self, cluster, worker):
         # Ignore if cluster or worker isn't active (

--- a/dask-gateway-server/dask_gateway_server/managers/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/base.py
@@ -1,7 +1,7 @@
-from traitlets import Unicode, Float, Integer, Dict, Bool
+from traitlets import Unicode, Float, Integer, Dict, Bool, Instance
 from traitlets.config import LoggingConfigurable
 
-from ..utils import MemoryLimit
+from ..utils import MemoryLimit, TaskPool
 
 
 class ClusterManager(LoggingConfigurable):
@@ -114,6 +114,7 @@ class ClusterManager(LoggingConfigurable):
     )
 
     # Parameters forwarded by gateway application
+    task_pool = Instance(TaskPool, args=())
     api_url = Unicode()
     temp_dir = Unicode()
 

--- a/dask-gateway-server/dask_gateway_server/managers/jobqueue/launcher.py
+++ b/dask-gateway-server/dask_gateway_server/managers/jobqueue/launcher.py
@@ -1,0 +1,80 @@
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+
+def finish(**kwargs):
+    json.dump(kwargs, sys.stdout)
+    sys.stdout.flush()
+
+
+def run_command(cmd, env):
+    proc = subprocess.Popen(
+        cmd,
+        env=env,
+        cwd=os.path.expanduser("~"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    stdout, stderr = proc.communicate()
+
+    finish(
+        ok=True,
+        returncode=proc.returncode,
+        stdout=stdout.decode("utf8", "replace"),
+        stderr=stderr.decode("utf8", "replace"),
+    )
+
+
+def start(cmd, env, staging_dir=None, files=None):
+    if staging_dir:
+        try:
+            os.makedirs(staging_dir, mode=0o700, exist_ok=False)
+            for name, value in files.items():
+                with open(os.path.join(staging_dir, name), "w") as f:
+                    f.write(value)
+        except Exception as exc:
+            finish(
+                ok=False,
+                error="Error setting up staging directory %s: %s" % (staging_dir, exc),
+            )
+            return
+    run_command(cmd, env)
+
+
+def stop(cmd, env, staging_dir=None):
+    if staging_dir:
+        if not os.path.exists(staging_dir):
+            return
+        try:
+            shutil.rmtree(staging_dir)
+        except Exception as exc:
+            finish(
+                ok=False,
+                error="Error removing staging directory %s: %s" % (staging_dir, exc),
+            )
+            return
+    run_command(cmd, env)
+
+
+def main():
+    try:
+        kwargs = json.load(sys.stdin)
+    except ValueError as exc:
+        finish(ok=False, error=str(exc))
+        return
+
+    action = kwargs.pop("action", None)
+    if action == "start":
+        start(**kwargs)
+    elif action == "stop":
+        stop(**kwargs)
+    else:
+        finish(ok=False, error="Valid actions are 'start' and 'stop'")
+
+
+if __name__ == "__main__":
+    main()

--- a/dask-gateway-server/dask_gateway_server/managers/jobqueue/pbs.py
+++ b/dask-gateway-server/dask_gateway_server/managers/jobqueue/pbs.py
@@ -1,0 +1,317 @@
+import asyncio
+import json
+import math
+import os
+import pwd
+import shutil
+import socket
+
+from traitlets import Unicode, Bool, default
+
+from ..base import ClusterManager
+
+
+__all__ = ("PBSClusterManager",)
+
+
+def qsub_format_memory(n):
+    """Format memory in bytes for use in qsub resources."""
+    if n >= 10 * (1024 ** 3):
+        return "%dGB" % math.ceil(n / (1024 ** 3))
+    if n >= 10 * (1024 ** 2):
+        return "%dMB" % math.ceil(n / (1024 ** 2))
+    if n >= 10 * 1024:
+        return "%dkB" % math.ceil(n / 1024)
+    return "%dB" % n
+
+
+class PBSClusterManager(ClusterManager):
+    """A cluster manager for deploying Dask on a PBS cluster."""
+
+    queue = Unicode("", help="The queue to submit jobs to.", config=True)
+
+    account = Unicode(
+        "", help="Accounting string associated with each job.", config=True
+    )
+
+    project = Unicode("", help="Project associated with each job.", config=True)
+
+    worker_resource_list = Unicode(
+        "select=1:ncpus={cores}:mem={memory}",
+        help="""
+        The resource list to use for the workers.
+
+        This is a template, and receives the following fields:
+
+        - cores
+        - memory
+        """,
+        config=True,
+    )
+
+    scheduler_resource_list = Unicode(
+        "select=1:ncpus={cores}:mem={memory}",
+        help="""
+        The resource list to use for the scheduler.
+
+        This is a template, and receives the following fields:
+
+        - cores
+        - memory
+        """,
+        config=True,
+    )
+
+    worker_setup = Unicode(
+        "", help="Script to run before dask worker starts.", config=True
+    )
+
+    scheduler_setup = Unicode(
+        "", help="Script to run before dask scheduler starts.", config=True
+    )
+
+    staging_directory = Unicode(
+        "{home}/.dask-gateway/",
+        help="""
+        The staging directory for storing files before the job starts.
+
+        A subdirectory will be created for each new cluster which will store
+        temporary files for that cluster. On cluster shutdown the subdirectory
+        will be removed.
+
+        This field can be a template, which recieves the following fields:
+
+        - home (the user's home directory)
+        - username (the user's name)
+        """,
+        config=True,
+    )
+
+    use_stagein = Bool(
+        True,
+        help="""
+        If true, the staging directory created above will be copied into the
+        job working directories at runtime using the ``-Wstagein`` directive.
+
+        If the staging directory is on a networked filesystem, you can set this
+        to False and rely on the networked filesystem for access.
+        """,
+        config=True,
+    )
+
+    # The following fields are configurable only for just-in-case reasons. The
+    # defaults should be sufficient for most users.
+
+    gateway_hostname = Unicode(
+        help="""
+        The hostname of the node running the gateway. Used for referencing the
+        local host in PBS directives.
+        """,
+        config=True,
+    )
+
+    @default("gateway_hostname")
+    def _default_gateway_hostname(self):
+        return socket.gethostname()
+
+    dask_gateway_jobqueue_launcher = Unicode(
+        help="The path to the dask-gateway-jobqueue-launcher executable", config=True
+    )
+
+    @default("dask_gateway_jobqueue_launcher")
+    def _default_launcher_path(self):
+        return (
+            shutil.which("dask-gateway-jobqueue-launcher")
+            or "dask-gateway-jobqueue-launcher"
+        )
+
+    submit_command = Unicode(help="The path to the job submit command", config=True)
+
+    @default("submit_command")
+    def _default_submit_command(self):
+        return shutil.which("qsub") or "qsub"
+
+    cancel_command = Unicode(help="The path to the job cancel command", config=True)
+
+    @default("cancel_command")
+    def _default_cancel_command(self):
+        return shutil.which("qdel") or "qdel"
+
+    def get_worker_args(self):
+        return [
+            "--nthreads",
+            str(self.worker_cores),
+            "--memory-limit",
+            str(self.worker_memory),
+        ]
+
+    @property
+    def worker_command(self):
+        """The full command (with args) to launch a dask worker"""
+        return " ".join([self.worker_cmd] + self.get_worker_args())
+
+    @property
+    def scheduler_command(self):
+        """The full command (with args) to launch a dask scheduler"""
+        return self.scheduler_cmd
+
+    def format_resource_list(self, template, cores, memory):
+        return template.format(cores=cores, memory=qsub_format_memory(memory))
+
+    def get_staging_directory(self, cluster_info):
+        staging_dir = self.staging_directory.format(
+            home=pwd.getpwnam(cluster_info.username).pw_dir,
+            username=cluster_info.username,
+        )
+        return os.path.join(staging_dir, cluster_info.cluster_name)
+
+    def get_tls_paths(self, cluster_info):
+        """Get the absolute paths to the tls cert and key files."""
+        if self.use_stagein:
+            cert_path = "dask.crt"
+            key_path = "dask.pem"
+        else:
+            staging_dir = self.get_staging_directory(cluster_info)
+            cert_path = os.path.join(staging_dir, "dask.crt")
+            key_path = os.path.join(staging_dir, "dask.pem")
+        return cert_path, key_path
+
+    def get_submit_cmd_and_env(self, cluster_info, worker_name=None):
+        env = self.get_env(cluster_info)
+
+        cmd = [self.submit_command]
+        cmd.extend(["-N", "dask-gateway"])
+        if self.queue:
+            cmd.extend(["-q", self.queue])
+        if self.account:
+            cmd.extend(["-A", self.account])
+        if self.project:
+            cmd.extend(["-P", self.project])
+        cmd.extend(["-j", "eo", "-R", "eo", "-Wsandbox=PRIVATE"])
+
+        if self.use_stagein:
+            staging_dir = self.get_staging_directory(cluster_info)
+            cmd.append("-Wstagein=.@%s:%s/*" % (self.gateway_hostname, staging_dir))
+
+        if worker_name:
+            env["DASK_GATEWAY_WORKER_NAME"] = worker_name
+            resources = self.format_resource_list(
+                self.worker_resource_list, self.worker_cores, self.worker_memory
+            )
+            script = "\n".join([self.worker_setup, self.worker_command])
+        else:
+            resources = self.format_resource_list(
+                self.scheduler_resource_list,
+                self.scheduler_cores,
+                self.scheduler_memory,
+            )
+            script = "\n".join([self.scheduler_setup, self.scheduler_command])
+
+        cmd.extend(["-v", ",".join(sorted(env))])
+        cmd.extend(["-l", resources])
+        cmd.extend(["--", "/bin/sh", "-c", script])
+
+        return cmd, env
+
+    def get_stop_cmd_env(self, job_id):
+        return [self.cancel_command, job_id], {}
+
+    async def do_as_user(self, user, action, **kwargs):
+        cmd = ["sudo", "-nHu", user, self.dask_gateway_jobqueue_launcher]
+        kwargs["action"] = action
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            env={},
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate(json.dumps(kwargs).encode("utf8"))
+        stdout = stdout.decode("utf8", "replace")
+        stderr = stderr.decode("utf8", "replace")
+
+        if proc.returncode != 0:
+            raise Exception(
+                "Error running `dask-gateway-jobqueue-launcher`\n"
+                "  returncode: %d\n"
+                "  stdout: %s\n"
+                "  stderr: %s" % (proc.returncode, stdout, stderr)
+            )
+        result = json.loads(stdout)
+        if not result["ok"]:
+            raise Exception(result["error"])
+        return result["returncode"], result["stdout"], result["stderr"]
+
+    def parse_job_id(self, stdout):
+        return stdout.strip()
+
+    async def start_job(self, cluster_info, worker_name=None):
+        cmd, env = self.get_submit_cmd_and_env(cluster_info, worker_name=worker_name)
+        if not worker_name:
+            staging_dir = self.get_staging_directory(cluster_info)
+            files = {
+                "dask.pem": cluster_info.tls_key.decode("utf8"),
+                "dask.crt": cluster_info.tls_cert.decode("utf8"),
+            }
+        else:
+            staging_dir = files = None
+
+        code, stdout, stderr = await self.do_as_user(
+            user=cluster_info.username,
+            action="start",
+            cmd=cmd,
+            env=env,
+            staging_dir=staging_dir,
+            files=files,
+        )
+        if code != 0:
+            raise Exception(
+                (
+                    "Failed to submit job to batch system\n"
+                    "  exit_code: %d\n"
+                    "  stdout: %s\n"
+                    "  stderr: %s"
+                )
+                % (code, stdout, stderr)
+            )
+        return self.parse_job_id(stdout)
+
+    async def stop_job(self, cluster_info, job_id, worker_name=None):
+        cmd, env = self.get_stop_cmd_env(job_id)
+
+        if not worker_name:
+            staging_dir = self.get_staging_directory(cluster_info)
+        else:
+            staging_dir = None
+
+        code, stdout, stderr = await self.do_as_user(
+            user=cluster_info.username,
+            action="stop",
+            cmd=cmd,
+            env=env,
+            staging_dir=staging_dir,
+        )
+        if code != 0 and "Job has finished" not in stderr:
+            raise Exception(
+                "Failed to stop job_id %s" % (job_id, cluster_info.cluster_name)
+            )
+
+    async def start_cluster(self, cluster_info):
+        job_id = await self.start_job(cluster_info)
+        yield {"job_id": job_id}
+
+    async def stop_cluster(self, cluster_info, cluster_state):
+        job_id = cluster_state.get("job_id")
+        if job_id is None:
+            return
+        await self.stop_job(cluster_info, job_id)
+
+    async def start_worker(self, worker_name, cluster_info, cluster_state):
+        job_id = await self.start_job(cluster_info, worker_name=worker_name)
+        yield {"job_id": job_id}
+
+    async def stop_worker(self, worker_name, worker_state, cluster_info, cluster_state):
+        job_id = worker_state.get("job_id")
+        if job_id is None:
+            return
+        await self.stop_job(cluster_info, job_id, worker_name=worker_name)

--- a/dask-gateway-server/dask_gateway_server/managers/jobqueue/pbs.py
+++ b/dask-gateway-server/dask_gateway_server/managers/jobqueue/pbs.py
@@ -348,7 +348,7 @@ class PBSClusterManager(ClusterManager):
     def is_job_running(self, job_id):
         if not hasattr(self, "job_tracker"):
             self.jobs_to_track = WeakValueDictionary()
-            self.job_tracker = self.parent.create_background_task(
+            self.job_tracker = self.task_pool.create_background_task(
                 self.job_status_tracker()
             )
 

--- a/dask-gateway-server/setup.py
+++ b/dask-gateway-server/setup.py
@@ -119,7 +119,13 @@ setup(
     extras_require=extras_require,
     python_requires=">=3.6",
     entry_points={
-        "console_scripts": ["dask-gateway-server = dask_gateway_server.app:main"]
+        "console_scripts": [
+            "dask-gateway-server = dask_gateway_server.app:main",
+            (
+                "dask-gateway-jobqueue-launcher = "
+                "dask_gateway_server.managers.jobqueue.launcher:main"
+            ),
+        ]
     },
     zip_safe=False,
 )

--- a/tests/test_local_cluster.py
+++ b/tests/test_local_cluster.py
@@ -15,11 +15,11 @@ class TestLocalClusterManager(ClusterManagerTests):
     def new_manager(self, **kwargs):
         return LocalTestingClusterManager(**kwargs)
 
-    def is_cluster_running(self, manager, cluster_info, cluster_state):
+    def cluster_is_running(self, manager, cluster_info, cluster_state):
         pid = cluster_state.get("pid")
         return is_running(pid) if pid is not None else False
 
-    def is_worker_running(self, manager, cluster_info, cluster_state, worker_state):
+    def worker_is_running(self, manager, cluster_info, cluster_state, worker_state):
         pid = worker_state.get("pid")
         return is_running(pid) if pid is not None else False
 

--- a/tests/test_pbs_cluster.py
+++ b/tests/test_pbs_cluster.py
@@ -1,0 +1,111 @@
+import os
+import subprocess
+
+import pytest
+
+if not os.environ.get("TEST_DASK_GATEWAY_PBS"):
+    pytest.skip("Not running PBS tests", allow_module_level=True)
+
+from dask_gateway_server.managers.jobqueue.pbs import (
+    PBSClusterManager,
+    qsub_format_memory,
+)
+
+from .utils import ClusterManagerTests
+
+
+pytestmark = pytest.mark.usefixtures("cleanup_jobs")
+
+
+JOBIDS = set()
+
+
+def kill_job(job_id):
+    try:
+        subprocess.check_output(["/opt/pbs/bin/qdel", job_id], stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as exc:
+        if b"Job has finished" not in exc.output:
+            print("Failed to stop %s, output: %s" % (job_id, exc.output.decode()))
+
+
+def is_job_running(job_id):
+    stdout = subprocess.check_output(["/opt/pbs/bin/qstat", "-x", job_id]).decode()
+    line = stdout.splitlines()[2]
+    out = line.split()[4] in ("R", "Q", "H")
+    return out
+
+
+@pytest.fixture(scope="module")
+def cleanup_jobs():
+    yield
+
+    if not JOBIDS:
+        return
+
+    for job in JOBIDS:
+        kill_job(job)
+
+    print("-- Stopped %d lost clusters --" % len(JOBIDS))
+
+
+class PBSTestingClusterManager(PBSClusterManager):
+    async def start_cluster(self, *args, **kwargs):
+        async for state in super().start_cluster(*args, **kwargs):
+            JOBIDS.add(state["job_id"])
+            yield state
+
+    async def stop_cluster(self, cluster_info, cluster_state):
+        job_id = cluster_state.get("job_id")
+        await super().stop_cluster(cluster_info, cluster_state)
+        JOBIDS.discard(job_id)
+
+
+class TestPBSClusterManager(ClusterManagerTests):
+    async def cleanup_cluster(
+        self, manager, cluster_info, cluster_state, worker_states
+    ):
+        job_id = cluster_state.get("job_id")
+        if job_id:
+            kill_job(job_id)
+
+    def new_manager(self, **kwargs):
+        return PBSTestingClusterManager(
+            scheduler_cmd="/opt/miniconda/bin/dask-gateway-scheduler",
+            worker_cmd="/opt/miniconda/bin/dask-gateway-worker",
+            scheduler_memory="512M",
+            worker_memory="512M",
+            scheduler_cores=1,
+            worker_cores=1,
+            cluster_start_timeout=30,
+            use_stagein=True,
+            **kwargs,
+        )
+
+    def cluster_is_running(self, manager, cluster_info, cluster_state):
+        job_id = cluster_state.get("job_id")
+        if not job_id:
+            return False
+        return is_job_running(job_id)
+
+    def worker_is_running(self, manager, cluster_info, cluster_state, worker_state):
+        job_id = worker_state.get("job_id")
+        if not job_id:
+            return False
+        return is_job_running(job_id)
+
+    def num_start_cluster_stages(self):
+        return 1
+
+    def num_start_worker_stages(self):
+        return 1
+
+
+def test_qsub_format_memory():
+    assert qsub_format_memory(2) == "2B"
+    assert qsub_format_memory(2 ** 10) == "1024B"
+    assert qsub_format_memory(2 ** 20) == "1024kB"
+    assert qsub_format_memory(2 ** 20 + 1) == "1025kB"
+    assert qsub_format_memory(2 ** 30) == "1024MB"
+    assert qsub_format_memory(2 ** 30 + 1) == "1025MB"
+    assert qsub_format_memory(2 ** 40) == "1024GB"
+    assert qsub_format_memory(2 ** 40 + 1) == "1025GB"

--- a/tests/test_yarn_cluster.py
+++ b/tests/test_yarn_cluster.py
@@ -67,14 +67,14 @@ class TestYarnClusterManager(ClusterManagerTests):
             **kwargs,
         )
 
-    def is_cluster_running(self, manager, cluster_info, cluster_state):
+    def cluster_is_running(self, manager, cluster_info, cluster_state):
         app_id = cluster_state.get("app_id")
         if not app_id:
             return False
         report = manager.skein_client.application_report(app_id)
         return report.state not in ("FINISHED", "FAILED", "KILLED")
 
-    def is_worker_running(self, manager, cluster_info, cluster_state, worker_state):
+    def worker_is_running(self, manager, cluster_info, cluster_state, worker_state):
         app_id = cluster_state.get("app_id")
         container_id = worker_state.get("container_id")
         if not app_id or not container_id:


### PR DESCRIPTION
Adds initial support for the PBS job queue system.

This works by using an intermediate script (`dask-gateway-jobqueue-launcher`) to do the heavy lifting of submitting/killing jobs. The gateway user then needs sudo access for this script for all dask users.

The gateway also needs to be a PBS operator in order to check the job status of all users. This could be worked around, but avoiding being an operator would likely be more expensive as `sudo` would have to be used for status queries as well.

The configurable fields exposed here were my best attempt at determining which parameters were important for users (balancing flexibility with ease of use). Not being a PBS user myself, I've likely done a poor job at determining what's important.