### PR TITLE
Cluster manager status polling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
               go test
               popd
 
-        - if: (commit_message !~ skip-tests) AND (commit_message ~= test-yarn)
+        - if: (commit_message !~ skip-tests) AND ((commit_message ~= test-all) OR (commit_message ~= test-yarn))
           env:
             - YARN-TESTS=true
           services:
@@ -46,7 +46,7 @@ jobs:
           script:
             - docker exec master /working/continuous_integration/docker/hadoop/script.sh
 
-        - if: (commit_message !~ skip-tests) AND (commit_message ~= test-kube)
+        - if: (commit_message !~ skip-tests) AND ((commit_message ~= test-all) OR (commit_message ~= test-kube))
           env:
             - KUBERNETES-TESTS=true
           services:
@@ -59,7 +59,7 @@ jobs:
           script:
             - ./continuous_integration/kubernetes/script.sh
 
-        - if: (commit_message !~ skip-tests) AND ((commit_message ~= test-jobqueue) OR (commit_message ~= test-pbs))
+        - if: (commit_message !~ skip-tests) AND ((commit_message ~= test-all) OR (commit_message ~= test-jobqueue) OR (commit_message ~= test-pbs))
           env:
             - PBS-TESTS=true
           services:
@@ -71,7 +71,7 @@ jobs:
           script:
             - docker exec -u dask pbs /working/continuous_integration/docker/pbs/script.sh
 
-        - if: (commit_message !~ skip-tests) AND ((commit_message ~= test-jobqueue) OR (commit_message ~= test-slurm))
+        - if: (commit_message !~ skip-tests) AND ((commit_message ~= test-all) OR (commit_message ~= test-jobqueue) OR (commit_message ~= test-slurm))
           env:
             - SLURM-TESTS=true
           services:

--- a/dask-gateway-server/dask_gateway_server/managers/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/base.py
@@ -36,6 +36,18 @@ class ClusterManager(LoggingConfigurable):
         config=True,
     )
 
+    cluster_status_period = Float(
+        30,
+        help="""
+        Time (in seconds) between cluster status checks.
+
+        A smaller period will detect failed clusters sooner, but will use more
+        resources. A larger period will provide slower feedback in the presence
+        of failures.
+        """,
+        config=True,
+    )
+
     worker_start_timeout = Float(
         60,
         help="""
@@ -170,6 +182,27 @@ class ClusterManager(LoggingConfigurable):
             multiple stages, can iteratively yield state updates to be
             checkpointed. If an error occurs at any time, the last yielded
             state will be used when calling ``stop_cluster``.
+        """
+        raise NotImplementedError
+
+    async def cluster_status(self, cluster_info, cluster_state):
+        """Check the status of a cluster.
+
+        Called periodically to check the status of a cluster.
+
+        Parameters
+        ----------
+        cluster_info : ClusterInfo
+            Information about the cluster.
+        cluster_state : dict
+            Any additional state returned from ``start_cluster``.
+
+        Returns
+        -------
+        running : bool
+            Whether the cluster is running.
+        msg : str, optional
+            If not running, an optional message describing the exit condition.
         """
         raise NotImplementedError
 

--- a/dask-gateway-server/dask_gateway_server/managers/inprocess.py
+++ b/dask-gateway-server/dask_gateway_server/managers/inprocess.py
@@ -38,6 +38,12 @@ class InProcessClusterManager(UnsafeLocalClusterManager):
         self.active_schedulers[cluster_info.cluster_name] = scheduler
         yield {}
 
+    async def cluster_status(self, cluster_info, cluster_state):
+        scheduler = self.active_schedulers.get(cluster_info.cluster_name)
+        if scheduler is None:
+            return False
+        return not scheduler.status.startswith("clos")
+
     async def stop_cluster(self, cluster_info, cluster_state):
         scheduler = self.active_schedulers.pop(cluster_info.cluster_name, None)
         if scheduler is None:

--- a/dask-gateway-server/dask_gateway_server/managers/jobqueue/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/jobqueue/base.py
@@ -3,7 +3,6 @@ import json
 import os
 import pwd
 import shutil
-from weakref import WeakValueDictionary
 
 from traitlets import Float, Unicode, default
 
@@ -41,11 +40,19 @@ class JobQueueClusterManager(ClusterManager):
         config=True,
     )
 
-    status_poll_interval = Float(
-        0.5,
-        help="The interval (in seconds) in which to poll for job statuses.",
+    job_status_period = Float(
+        help="""
+        Time (in seconds) between job status checks.
+
+        This should be <= ``cluster_status_period``. The default is
+        ``cluster_status_period``.
+        """,
         config=True,
     )
+
+    @default("job_status_period")
+    def _default_job_status_period(self):
+        return self.cluster_status_period
 
     # The following fields are configurable only for just-in-case reasons. The
     # defaults should be sufficient for most users.
@@ -66,6 +73,16 @@ class JobQueueClusterManager(ClusterManager):
     cancel_command = Unicode(help="The path to the job cancel command", config=True)
 
     status_command = Unicode(help="The path to the job status command", config=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Initialize the background status task
+        self.jobs_to_track = set()
+        self.job_states = {}
+        self.job_tracker = self.task_pool.create_background_task(
+            self.job_state_tracker()
+        )
 
     def get_worker_args(self):
         return [
@@ -215,56 +232,50 @@ class JobQueueClusterManager(ClusterManager):
                         stderr,
                     )
 
-                running, failed = self.parse_job_states(stdout)
-
-                for job_id in running:
-                    fut = self.jobs_to_track.pop(job_id, None)
-                    if fut:
-                        fut.set_result(True)
-                for job_id in failed:
-                    fut = self.jobs_to_track.pop(job_id, None)
-                    if fut:
-                        fut.set_result(False)
+                finished_states = self.parse_job_states(stdout)
+                self.job_states.update(finished_states)
+                self.jobs_to_track.difference_update(finished_states)
 
             await asyncio.sleep(self.status_poll_interval)
 
-    def is_job_running(self, job_id):
-        if not hasattr(self, "job_tracker"):
-            self.jobs_to_track = WeakValueDictionary()
-            self.job_tracker = self.task_pool.create_background_task(
-                self.job_state_tracker()
-            )
+    def track_job(self, job_id):
+        self.jobs_to_track.add(job_id)
 
-        if job_id not in self.jobs_to_track:
-            loop = asyncio.get_running_loop()
-            fut = self.jobs_to_track[job_id] = loop.create_future()
-        else:
-            fut = self.jobs_to_track[job_id]
-        return fut
+    def untrack_job(self, job_id):
+        self.jobs_to_track.discard(job_id)
+        self.job_states.pop(job_id, None)
+
+    def get_job_state(self, job_id):
+        return self.job_states.get(job_id)
+
+    async def cluster_status(self, cluster_info, cluster_state):
+        self.log.debug("cluster_status for %s", cluster_info.cluster_name)
+
+        job_id = cluster_state.get("job_id")
+        if job_id is None:
+            return False, None
+
+        state = self.get_job_state(job_id)
+        if state is not None:
+            self.untrack_job(job_id)
+            return False, "Job %s completed with state %s" % (job_id, state)
+        return True, None
 
     async def start_cluster(self, cluster_info):
         job_id = await self.start_job(cluster_info)
         yield {"job_id": job_id}
-        if not await self.is_job_running(job_id):
-            raise Exception(
-                "Job %s for cluster %s failed, see logs for more information"
-                % (job_id, cluster_info.cluster_name)
-            )
+        self.track_job(job_id)
 
     async def stop_cluster(self, cluster_info, cluster_state):
         job_id = cluster_state.get("job_id")
         if job_id is None:
             return
+        self.untrack_job(job_id)
         await self.stop_job(cluster_info, job_id)
 
     async def start_worker(self, worker_name, cluster_info, cluster_state):
         job_id = await self.start_job(cluster_info, worker_name=worker_name)
         yield {"job_id": job_id}
-        if not await self.is_job_running(job_id):
-            raise Exception(
-                "Job %s for worker %s failed, see logs for more information"
-                % (job_id, worker_name)
-            )
 
     async def stop_worker(self, worker_name, worker_state, cluster_info, cluster_state):
         job_id = worker_state.get("job_id")

--- a/dask-gateway-server/dask_gateway_server/managers/jobqueue/pbs.py
+++ b/dask-gateway-server/dask_gateway_server/managers/jobqueue/pbs.py
@@ -157,15 +157,13 @@ class PBSClusterManager(JobQueueClusterManager):
 
     def parse_job_states(self, stdout):
         lines = stdout.splitlines()[2:]
-        running = []
-        failed = []
+
+        finished = {}
 
         for l in lines:
             parts = l.split()
             job_id = parts[0]
             status = parts[4]
-            if status == "R":
-                running.append(job_id)
-            elif status not in ("Q", "H"):
-                failed.append(job_id)
-        return running, failed
+            if status not in ("R", "Q", "H"):
+                finished[job_id] = status
+        return finished

--- a/dask-gateway-server/dask_gateway_server/managers/jobqueue/slurm.py
+++ b/dask-gateway-server/dask_gateway_server/managers/jobqueue/slurm.py
@@ -93,13 +93,10 @@ class SlurmClusterManager(JobQueueClusterManager):
         return stdout.strip()
 
     def parse_job_states(self, stdout):
-        running = []
-        failed = []
+        finished = {}
 
         for l in stdout.splitlines():
             job_id, state = l.split()
-            if state in ("R", "CG"):
-                running.append(job_id)
-            elif state not in ("PD", "CF"):
-                failed.append(job_id)
-        return running, failed
+            if state not in ("R", "CG", "PD", "CF"):
+                finished[job_id] = state
+        return finished

--- a/dask-gateway-server/dask_gateway_server/managers/local.py
+++ b/dask-gateway-server/dask_gateway_server/managers/local.py
@@ -260,6 +260,12 @@ class LocalClusterManager(ClusterManager):
         )
         yield {"pid": pid}
 
+    async def cluster_status(self, cluster_info, cluster_state):
+        pid = cluster_state.get("pid")
+        if pid is not None:
+            return is_running(pid)
+        return False
+
     async def stop_cluster(self, cluster_info, cluster_state):
         pid = cluster_state.get("pid")
         if pid is not None:

--- a/dask-gateway-server/dask_gateway_server/objects.py
+++ b/dask-gateway-server/dask_gateway_server/objects.py
@@ -452,6 +452,7 @@ class Cluster(object):
         self.lock = asyncio.Lock(loop=loop)
         self._start_future = loop.create_future()
         self._connect_future = loop.create_future()
+        self._status_monitor = None
         if status >= ClusterStatus.RUNNING:
             # Already running, create finished futures to mark
             self._start_future.set_result(True)

--- a/tests/test_pbs_cluster.py
+++ b/tests/test_pbs_cluster.py
@@ -77,6 +77,7 @@ class TestPBSClusterManager(ClusterManagerTests):
             scheduler_cores=1,
             worker_cores=1,
             cluster_start_timeout=30,
+            job_status_period=0.5,
             use_stagein=True,
             **kwargs,
         )

--- a/tests/test_slurm_cluster.py
+++ b/tests/test_slurm_cluster.py
@@ -80,6 +80,7 @@ class TestSlurmClusterManager(ClusterManagerTests):
             scheduler_cores=1,
             worker_cores=1,
             cluster_start_timeout=30,
+            job_status_period=0.5,
             **kwargs,
         )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -231,11 +231,22 @@ class ClusterManagerTests(object):
             time.sleep(0.25)
         return False
 
+    async def cluster_status(self, manager, cluster):
+        out = await manager.cluster_status(cluster.info, cluster.state)
+        if isinstance(out, tuple):
+            res, msg = out
+            assert isinstance(msg, str) or msg is None
+        else:
+            res = out
+        return res
+
     @pytest.mark.asyncio
     @gateway_test
     async def test_start_stop_cluster(self, gateway, manager):
         # Create a new cluster
         cluster = gateway.new_cluster()
+
+        assert not await self.cluster_status(manager, cluster)
 
         # Start the cluster
         async for state in manager.start_cluster(cluster.info):
@@ -244,10 +255,13 @@ class ClusterManagerTests(object):
         # Wait for connection
         await asyncio.wait_for(cluster._connect_future, manager.cluster_connect_timeout)
         assert self.cluster_is_running(manager, cluster.info, cluster.state)
+        assert await self.cluster_status(manager, cluster)
 
         # Stop the cluster
         await manager.stop_cluster(cluster.info, cluster.state)
         assert self.cluster_is_stopped(manager, cluster.info, cluster.state)
+        assert not await self.cluster_status(manager, cluster)
+
         gateway.mark_cluster_stopped(cluster.name)
 
     async def check_cancel_during_cluster_startup(self, gateway, manager, fail_stage):
@@ -266,6 +280,9 @@ class ClusterManagerTests(object):
 
         # Cleanup cancelled async generator
         await start_task.athrow(GeneratorExit)
+
+        # Assert not running
+        assert not await self.cluster_status(manager, cluster)
 
         # Stop the cluster
         await manager.stop_cluster(cluster.info, cluster.state)
@@ -291,6 +308,7 @@ class ClusterManagerTests(object):
         # Wait for connection
         await asyncio.wait_for(cluster._connect_future, manager.cluster_connect_timeout)
         assert self.cluster_is_running(manager, cluster.info, cluster.state)
+        assert await self.cluster_status(manager, cluster)
 
         # Create a new worker
         worker = gateway.new_worker(cluster.name)
@@ -332,6 +350,7 @@ class ClusterManagerTests(object):
         # Wait for connection
         await asyncio.wait_for(cluster._connect_future, manager.cluster_connect_timeout)
         assert self.cluster_is_running(manager, cluster.info, cluster.state)
+        assert await self.cluster_status(manager, cluster)
 
         # Create a new worker
         worker = gateway.new_worker(cluster.name)


### PR DESCRIPTION
Allows tracking the status of clusters. This is useful for two reasons:

- It allows detecting cluster failures that occur *after* a cluster has started. Without this, failed clusters will remain in the gateway until deleted by a user.
- It removes any polling that a cluster manager might have done in the ``start_cluster`` method, and pulls it out into the gateway itself. This allows us to reduce the polling frequency, and provides a common configuration for setting the frequency.

Fixes #41.

We'll want to add a corresponding method for tracking worker status - this will be added in a subsequent PR.