### PR TITLE
Add `worker_status` checks

### DIFF
--- a/dask-gateway-server/dask_gateway_server/managers/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/base.py
@@ -15,7 +15,7 @@ class ClusterManager(LoggingConfigurable):
     )
 
     cluster_start_timeout = Float(
-        60,
+        30,
         help="""
         Timeout (in seconds) before giving up on a starting dask cluster.
 
@@ -26,7 +26,7 @@ class ClusterManager(LoggingConfigurable):
     )
 
     cluster_connect_timeout = Float(
-        30,
+        60,
         help="""
         Timeout (in seconds) for a started dask cluster to connect to the gateway.
 
@@ -49,7 +49,7 @@ class ClusterManager(LoggingConfigurable):
     )
 
     worker_start_timeout = Float(
-        60,
+        30,
         help="""
         Timeout (in seconds) before giving up on a starting dask worker.
         """,
@@ -57,7 +57,7 @@ class ClusterManager(LoggingConfigurable):
     )
 
     worker_connect_timeout = Float(
-        30,
+        60,
         help="""
         Timeout (in seconds) for a started dask worker to connect to the scheduler.
 

--- a/dask-gateway-server/dask_gateway_server/managers/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/base.py
@@ -67,6 +67,18 @@ class ClusterManager(LoggingConfigurable):
         config=True,
     )
 
+    worker_status_period = Float(
+        30,
+        help="""
+        Time (in seconds) between worker status checks.
+
+        A smaller period will detect failed workers sooner, but will use more
+        resources. A larger period will provide slower feedback in the presence
+        of failures.
+        """,
+        config=True,
+    )
+
     worker_memory = MemoryLimit(
         "2 G",
         help="""
@@ -242,6 +254,53 @@ class ClusterManager(LoggingConfigurable):
             state will be used when calling ``stop_worker``.
         """
         raise NotImplementedError
+
+    async def worker_status(
+        self, worker_name, worker_state, cluster_info, cluster_state
+    ):
+        """Check the status of a worker.
+
+        Called periodically to check the status of a worker. Once a worker is
+        running this method will no longer be called.
+
+        Parameters
+        ---------
+        worker_name : str
+            The worker name.
+        worker_state : dict
+            Any additional worker state returned from ``start_worker``.
+        cluster_info : ClusterInfo
+            Information about the cluster.
+        cluster_state : dict
+            Any additional state returned from ``start_cluster``.
+
+        Returns
+        -------
+        running : bool
+            Whether the worker is running.
+        msg : str, optional
+            If not running, an optional message describing the exit condition.
+        """
+        raise NotImplementedError
+
+    def on_worker_running(self, worker_name, worker_state, cluster_info, cluster_state):
+        """Called when a worker is marked as running.
+
+        Optional callback, useful for cluster managers that track worker state
+        in background tasks.
+
+        Parameters
+        ---------
+        worker_name : str
+            The worker name.
+        worker_state : dict
+            Any additional worker state returned from ``start_worker``.
+        cluster_info : ClusterInfo
+            Information about the cluster.
+        cluster_state : dict
+            Any additional state returned from ``start_cluster``.
+        """
+        pass
 
     async def stop_worker(self, worker_name, worker_state, cluster_info, cluster_state):
         """Remove a worker.

--- a/dask-gateway-server/dask_gateway_server/managers/inprocess.py
+++ b/dask-gateway-server/dask_gateway_server/managers/inprocess.py
@@ -61,6 +61,14 @@ class InProcessClusterManager(UnsafeLocalClusterManager):
         self.active_workers[worker_name] = worker
         yield {}
 
+    async def worker_status(
+        self, worker_name, worker_state, cluster_info, cluster_state
+    ):
+        worker = self.active_workers.get(worker_name)
+        if worker is None:
+            return False
+        return not worker.status.startswith("clos")
+
     async def stop_worker(self, worker_name, worker_state, cluster_info, cluster_state):
         worker = self.active_workers.pop(worker_name, None)
         if worker is None:

--- a/dask-gateway-server/dask_gateway_server/managers/local.py
+++ b/dask-gateway-server/dask_gateway_server/managers/local.py
@@ -281,6 +281,14 @@ class LocalClusterManager(ClusterManager):
         )
         yield {"pid": pid}
 
+    async def worker_status(
+        self, worker_name, worker_state, cluster_info, cluster_state
+    ):
+        pid = worker_state.get("pid")
+        if pid is not None:
+            return is_running(pid)
+        return False
+
     async def stop_worker(self, worker_name, worker_state, cluster_info, cluster_state):
         pid = worker_state.get("pid")
         if pid is None:

--- a/dask-gateway/dask_gateway/dask_cli.py
+++ b/dask-gateway/dask_gateway/dask_cli.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import sys
-from disutils.version import LooseVersion
+from distutils.version import LooseVersion
 from urllib.parse import urlparse, quote
 
 from tornado import gen, web

--- a/dask-gateway/dask_gateway/dask_cli.py
+++ b/dask-gateway/dask_gateway/dask_cli.py
@@ -5,16 +5,18 @@ import json
 import logging
 import os
 import sys
+from disutils.version import LooseVersion
 from urllib.parse import urlparse, quote
 
 from tornado import gen, web
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 from tornado.ioloop import IOLoop, TimeoutError
+
+import distributed
 from distributed import Scheduler, Worker, Nanny
 from distributed.security import Security
 from distributed.utils import ignoring
 from distributed.cli.utils import install_signal_handlers
-
 from distributed.proctitle import (
     enable_proctitle_on_children,
     enable_proctitle_on_current,
@@ -365,14 +367,19 @@ async def start_worker(
 
     typ = Nanny if nanny else Worker
 
+    if LooseVersion(distributed.__version__) >= "2.0.0":
+        kwargs = {"nthreads": nthreads}
+    else:
+        kwargs = {"ncores": nthreads}
+
     worker = typ(
         scheduler,
-        nthreads=nthreads,
         loop=loop,
         memory_limit=memory_limit,
         security=security,
         name=worker_name,
         local_dir=local_dir,
+        **kwargs,
     )
 
     if nanny:

--- a/dask-gateway/dask_gateway/dask_cli.py
+++ b/dask-gateway/dask_gateway/dask_cli.py
@@ -367,7 +367,7 @@ async def start_worker(
 
     worker = typ(
         scheduler,
-        ncores=nthreads,
+        nthreads=nthreads,
         loop=loop,
         memory_limit=memory_limit,
         security=security,

--- a/tests/test_kubernetes_cluster.py
+++ b/tests/test_kubernetes_cluster.py
@@ -53,7 +53,6 @@ class TestKubeClusterManager(ClusterManagerTests):
             worker_memory="256M",
             scheduler_cores=0.1,
             worker_cores=0.1,
-            cluster_start_timeout=30,
             **kwargs,
         )
 

--- a/tests/test_yarn_cluster.py
+++ b/tests/test_yarn_cluster.py
@@ -64,6 +64,7 @@ class TestYarnClusterManager(ClusterManagerTests):
             scheduler_cores=1,
             worker_cores=1,
             cluster_start_timeout=30,
+            worker_status_period=0.5,
             **kwargs,
         )
 


### PR DESCRIPTION
Similar to `ClusterManager.cluster_status`, this adds
`ClusterManager.worker_status` for checking the status of a worker. This
allows detecting failed workers early (rather than waiting for
connection to timeout), while not consuming too many resources.

Second part of answering #41.