### PR TITLE
Move to one `ClusterManager` per cluster

### DIFF
--- a/dask-gateway-server/dask_gateway_server/managers/inprocess.py
+++ b/dask-gateway-server/dask_gateway_server/managers/inprocess.py
@@ -5,6 +5,7 @@ from dask_gateway.dask_cli import (
     start_worker,
 )
 from tornado import gen
+from traitlets import Any, Dict
 
 from .local import UnsafeLocalClusterManager
 
@@ -12,65 +13,59 @@ from .local import UnsafeLocalClusterManager
 class InProcessClusterManager(UnsafeLocalClusterManager):
     """A cluster manager that runs everything in the same process"""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.active_schedulers = {}
-        self.active_workers = {}
+    scheduler = Any()
+    workers = Dict()
 
-    def get_security(self, cluster_info):
-        cert_path, key_path = self.get_tls_paths(cluster_info)
+    def get_security(self):
+        cert_path, key_path = self.get_tls_paths()
         return make_security(cert_path, key_path)
 
-    def get_gateway_client(self, cluster_info):
+    def get_gateway_client(self):
         return make_gateway_client(
-            cluster_name=cluster_info.cluster_name,
-            api_token=cluster_info.api_token,
+            cluster_name=self.cluster_name,
+            api_token=self.api_token,
             api_url=self.api_url,
         )
 
-    async def start_cluster(self, cluster_info):
-        self.create_working_directory(cluster_info)
-        security = self.get_security(cluster_info)
-        gateway_client = self.get_gateway_client(cluster_info)
-        scheduler = await start_scheduler(
+    async def start_cluster(self):
+        self.create_working_directory()
+        security = self.get_security()
+        gateway_client = self.get_gateway_client()
+        self.scheduler = await start_scheduler(
             gateway_client, security, exit_on_failure=False
         )
-        self.active_schedulers[cluster_info.cluster_name] = scheduler
         yield {}
 
-    async def cluster_status(self, cluster_info, cluster_state):
-        scheduler = self.active_schedulers.get(cluster_info.cluster_name)
-        if scheduler is None:
+    async def cluster_status(self, cluster_state):
+        if self.scheduler is None:
             return False
-        return not scheduler.status.startswith("clos")
+        return not self.scheduler.status.startswith("clos")
 
-    async def stop_cluster(self, cluster_info, cluster_state):
-        scheduler = self.active_schedulers.pop(cluster_info.cluster_name, None)
-        if scheduler is None:
+    async def stop_cluster(self, cluster_state):
+        if self.scheduler is None:
             return
-        await scheduler.close(fast=True)
-        scheduler.stop()
+        await self.scheduler.close(fast=True)
+        self.scheduler.stop()
+        self.scheduler = None
 
-    async def start_worker(self, worker_name, cluster_info, cluster_state):
-        security = self.get_security(cluster_info)
-        gateway_client = self.get_gateway_client(cluster_info)
-        workdir = self.get_working_directory(cluster_info)
+    async def start_worker(self, worker_name, cluster_state):
+        security = self.get_security()
+        gateway_client = self.get_gateway_client()
+        workdir = self.get_working_directory()
         worker = await start_worker(
             gateway_client, security, worker_name, local_dir=workdir, nanny=False
         )
-        self.active_workers[worker_name] = worker
+        self.workers[worker_name] = worker
         yield {}
 
-    async def worker_status(
-        self, worker_name, worker_state, cluster_info, cluster_state
-    ):
-        worker = self.active_workers.get(worker_name)
+    async def worker_status(self, worker_name, worker_state, cluster_state):
+        worker = self.workers.get(worker_name)
         if worker is None:
             return False
         return not worker.status.startswith("clos")
 
-    async def stop_worker(self, worker_name, worker_state, cluster_info, cluster_state):
-        worker = self.active_workers.pop(worker_name, None)
+    async def stop_worker(self, worker_name, worker_state, cluster_state):
+        worker = self.workers.pop(worker_name, None)
         if worker is None:
             return
         try:

--- a/dask-gateway-server/dask_gateway_server/managers/jobqueue/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/jobqueue/base.py
@@ -4,12 +4,98 @@ import os
 import pwd
 import shutil
 
-from traitlets import Float, Unicode, default
+from traitlets import Float, Unicode, Instance, default
+from traitlets.config import SingletonConfigurable
 
 from ..base import ClusterManager
+from ...utils import TaskPool
 
 
-__all__ = ("JobQueueClusterManager",)
+__all__ = ("JobQueueClusterManager", "JobQueueStatusTracker")
+
+
+class JobQueueStatusTracker(SingletonConfigurable):
+    """A base class for tracking job status in a jobqueue cluster."""
+
+    query_period = Float(
+        30,
+        help="""
+        Time (in seconds) between job status checks.
+
+        This should be <= ``min(cluster_status_period, worker_status_period)``.
+        """,
+        config=True,
+    )
+
+    status_command = Unicode(help="The path to the job status command", config=True)
+
+    # forwarded by parent class
+    task_pool = Instance(TaskPool, args=())
+
+    def get_status_cmd_env(self, job_ids):
+        raise NotImplementedError
+
+    def parse_job_states(self, stdout):
+        raise NotImplementedError
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Initialize the background status task
+        self.jobs_to_track = set()
+        self.job_states = {}
+        self.job_tracker = self.task_pool.create_background_task(
+            self.job_state_tracker()
+        )
+
+    async def job_state_tracker(self):
+        while True:
+            if self.jobs_to_track:
+                self.log.debug("Polling status of %d jobs", len(self.jobs_to_track))
+                cmd, env = self.get_status_cmd_env(self.jobs_to_track)
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    env=env,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, stderr = await proc.communicate()
+                stdout = stdout.decode("utf8", "replace")
+                if proc.returncode != 0:
+                    stderr = stderr.decode("utf8", "replace")
+                    self.log.warning(
+                        "Job status check failed with returncode %d, stderr: %s",
+                        proc.returncode,
+                        stderr,
+                    )
+
+                finished_states = self.parse_job_states(stdout)
+                self.job_states.update(finished_states)
+                self.jobs_to_track.difference_update(finished_states)
+
+            await asyncio.sleep(self.query_period)
+
+    def track(self, job_id):
+        self.jobs_to_track.add(job_id)
+        # Indicate present but not finished. Stopped ids are deleted once their
+        # state is retrieved - missing records are always considered stopped.
+        self.job_states[job_id] = None
+
+    def untrack(self, job_id):
+        self.jobs_to_track.discard(job_id)
+        self.job_states.pop(job_id, None)
+
+    def status(self, job_id):
+        if job_id is None:
+            return False, None
+
+        if job_id in self.job_states:
+            state = self.job_states[job_id]
+            if state is not None:
+                return False, "Job %s completed with state %s" % (job_id, state)
+            return True, None
+        # Job already deleted from tracker
+        return False, None
 
 
 class JobQueueClusterManager(ClusterManager):
@@ -40,20 +126,6 @@ class JobQueueClusterManager(ClusterManager):
         config=True,
     )
 
-    job_status_period = Float(
-        help="""
-        Time (in seconds) between job status checks.
-
-        This should be <= ``cluster_status_period``. The default is
-        ``cluster_status_period``.
-        """,
-        config=True,
-    )
-
-    @default("job_status_period")
-    def _default_job_status_period(self):
-        return self.cluster_status_period
-
     # The following fields are configurable only for just-in-case reasons. The
     # defaults should be sufficient for most users.
 
@@ -71,18 +143,6 @@ class JobQueueClusterManager(ClusterManager):
     submit_command = Unicode(help="The path to the job submit command", config=True)
 
     cancel_command = Unicode(help="The path to the job cancel command", config=True)
-
-    status_command = Unicode(help="The path to the job status command", config=True)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Initialize the background status task
-        self.jobs_to_track = set()
-        self.job_states = {}
-        self.job_tracker = self.task_pool.create_background_task(
-            self.job_state_tracker()
-        )
 
     def get_worker_args(self):
         return [
@@ -102,31 +162,36 @@ class JobQueueClusterManager(ClusterManager):
         """The full command (with args) to launch a dask scheduler"""
         return self.scheduler_cmd
 
-    def get_submit_cmd_env_stdin(self, cluster_info, worker_name=None):
+    def get_submit_cmd_env_stdin(self, worker_name=None):
         raise NotImplementedError
 
     def get_stop_cmd_env(self, job_id):
         raise NotImplementedError
 
-    def get_status_cmd_env(self, job_ids):
-        raise NotImplementedError
-
     def parse_job_id(self, stdout):
         raise NotImplementedError
 
-    def parse_job_states(self, stdout):
+    def get_status_tracker(self):
         raise NotImplementedError
 
-    def get_staging_directory(self, cluster_info):
-        staging_dir = self.staging_directory.format(
-            home=pwd.getpwnam(cluster_info.username).pw_dir,
-            username=cluster_info.username,
-        )
-        return os.path.join(staging_dir, cluster_info.cluster_name)
+    def track_job(self, job_id):
+        self.get_status_tracker().track(job_id)
 
-    def get_tls_paths(self, cluster_info):
+    def untrack_job(self, job_id):
+        self.get_status_tracker().untrack(job_id)
+
+    def job_status(self, job_id):
+        return self.get_status_tracker().status(job_id)
+
+    def get_staging_directory(self):
+        staging_dir = self.staging_directory.format(
+            home=pwd.getpwnam(self.username).pw_dir, username=self.username
+        )
+        return os.path.join(staging_dir, self.cluster_name)
+
+    def get_tls_paths(self):
         """Get the absolute paths to the tls cert and key files."""
-        staging_dir = self.get_staging_directory(cluster_info)
+        staging_dir = self.get_staging_directory()
         cert_path = os.path.join(staging_dir, "dask.crt")
         key_path = os.path.join(staging_dir, "dask.pem")
         return cert_path, key_path
@@ -157,21 +222,19 @@ class JobQueueClusterManager(ClusterManager):
             raise Exception(result["error"])
         return result["returncode"], result["stdout"], result["stderr"]
 
-    async def start_job(self, cluster_info, worker_name=None):
-        cmd, env, stdin = self.get_submit_cmd_env_stdin(
-            cluster_info, worker_name=worker_name
-        )
+    async def start_job(self, worker_name=None):
+        cmd, env, stdin = self.get_submit_cmd_env_stdin(worker_name=worker_name)
         if not worker_name:
-            staging_dir = self.get_staging_directory(cluster_info)
+            staging_dir = self.get_staging_directory()
             files = {
-                "dask.pem": cluster_info.tls_key.decode("utf8"),
-                "dask.crt": cluster_info.tls_cert.decode("utf8"),
+                "dask.pem": self.tls_key.decode("utf8"),
+                "dask.crt": self.tls_cert.decode("utf8"),
             }
         else:
             staging_dir = files = None
 
         code, stdout, stderr = await self.do_as_user(
-            user=cluster_info.username,
+            user=self.username,
             action="start",
             cmd=cmd,
             env=env,
@@ -191,114 +254,52 @@ class JobQueueClusterManager(ClusterManager):
             )
         return self.parse_job_id(stdout)
 
-    async def stop_job(self, cluster_info, job_id, worker_name=None):
+    async def stop_job(self, job_id, worker_name=None):
         cmd, env = self.get_stop_cmd_env(job_id)
 
         if not worker_name:
-            staging_dir = self.get_staging_directory(cluster_info)
+            staging_dir = self.get_staging_directory()
         else:
             staging_dir = None
 
         code, stdout, stderr = await self.do_as_user(
-            user=cluster_info.username,
-            action="stop",
-            cmd=cmd,
-            env=env,
-            staging_dir=staging_dir,
+            user=self.username, action="stop", cmd=cmd, env=env, staging_dir=staging_dir
         )
         if code != 0 and "Job has finished" not in stderr:
-            raise Exception(
-                "Failed to stop job_id %s" % (job_id, cluster_info.cluster_name)
-            )
+            raise Exception("Failed to stop job_id %s" % (job_id, self.cluster_name))
 
-    async def job_state_tracker(self):
-        while True:
-            if self.jobs_to_track:
-                self.log.debug("Polling status of %d jobs", len(self.jobs_to_track))
-                cmd, env = self.get_status_cmd_env(self.jobs_to_track)
-                proc = await asyncio.create_subprocess_exec(
-                    *cmd,
-                    env=env,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                stdout, stderr = await proc.communicate()
-                stdout = stdout.decode("utf8", "replace")
-                if proc.returncode != 0:
-                    stderr = stderr.decode("utf8", "replace")
-                    self.log.warning(
-                        "Job status check failed with returncode %d, stderr: %s",
-                        proc.returncode,
-                        stderr,
-                    )
-
-                finished_states = self.parse_job_states(stdout)
-                self.job_states.update(finished_states)
-                self.jobs_to_track.difference_update(finished_states)
-
-            await asyncio.sleep(self.job_status_period)
-
-    def track_job(self, job_id):
-        self.jobs_to_track.add(job_id)
-        # Indicate present but not finished. Stopped ids are deleted once their
-        # state is retrieved - missing records are always considered stopped.
-        self.job_states[job_id] = None
-
-    def untrack_job(self, job_id):
-        self.jobs_to_track.discard(job_id)
-
-    def discard_job_state(self, job_id):
-        self.job_states.pop(job_id, None)
-
-    def job_status(self, job_id):
-        if job_id is None:
-            return False, None
-
-        if job_id in self.job_states:
-            state = self.job_states[job_id]
-            if state is not None:
-                return False, "Job %s completed with state %s" % (job_id, state)
-            return True, None
-        # Job already deleted from tracker
-        return False, None
-
-    async def cluster_status(self, cluster_info, cluster_state):
+    async def cluster_status(self, cluster_state):
         return self.job_status(cluster_state.get("job_id"))
 
-    async def worker_status(
-        self, worker_name, worker_state, cluster_info, cluster_state
-    ):
+    async def worker_status(self, worker_name, worker_state, cluster_state):
         return self.job_status(worker_state.get("job_id"))
 
-    def on_worker_running(self, worker_name, worker_state, cluster_info, cluster_state):
+    def on_worker_running(self, worker_name, worker_state, cluster_state):
         job_id = worker_state.get("job_id")
         if job_id is None:
             return
         self.untrack_job(job_id)
-        self.discard_job_state(job_id)
 
-    async def start_cluster(self, cluster_info):
-        job_id = await self.start_job(cluster_info)
+    async def start_cluster(self):
+        job_id = await self.start_job()
         yield {"job_id": job_id}
         self.track_job(job_id)
 
-    async def stop_cluster(self, cluster_info, cluster_state):
+    async def stop_cluster(self, cluster_state):
         job_id = cluster_state.get("job_id")
         if job_id is None:
             return
         self.untrack_job(job_id)
-        self.discard_job_state(job_id)
-        await self.stop_job(cluster_info, job_id)
+        await self.stop_job(job_id)
 
-    async def start_worker(self, worker_name, cluster_info, cluster_state):
-        job_id = await self.start_job(cluster_info, worker_name=worker_name)
+    async def start_worker(self, worker_name, cluster_state):
+        job_id = await self.start_job(worker_name=worker_name)
         yield {"job_id": job_id}
         self.track_job(job_id)
 
-    async def stop_worker(self, worker_name, worker_state, cluster_info, cluster_state):
+    async def stop_worker(self, worker_name, worker_state, cluster_state):
         job_id = worker_state.get("job_id")
         if job_id is None:
             return
         self.untrack_job(job_id)
-        self.discard_job_state(job_id)
-        await self.stop_job(cluster_info, job_id, worker_name=worker_name)
+        await self.stop_job(job_id, worker_name=worker_name)

--- a/dask-gateway-server/dask_gateway_server/utils.py
+++ b/dask-gateway-server/dask_gateway_server/utils.py
@@ -30,12 +30,17 @@ class TaskPool(object):
         # canceling them
         try:
             await asyncio.wait_for(
-                asyncio.gather(
-                    *getattr(self, "pending_tasks", ()), return_exceptions=True
-                ),
-                timeout,
+                asyncio.gather(*self.pending_tasks, return_exceptions=True), timeout
             )
         except (asyncio.TimeoutError, asyncio.CancelledError):
+            pass
+
+        # Now wait for all tasks to be actually completed
+        try:
+            await asyncio.gather(
+                *self.pending_tasks, *self.background_tasks, return_exceptions=True
+            )
+        except asyncio.CancelledError:
             pass
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,7 +11,6 @@ from dask_gateway_server.utils import random_port
 
 from .utils import temp_gateway
 
-
 try:
     import kerberos
 
@@ -20,6 +19,11 @@ try:
     requires_kerberos = pytest.mark.skipif(skip, reason="No kerberos server running")
 except ImportError:
     requires_kerberos = pytest.mark.skipif(True, reason="Cannot import kerberos")
+
+try:
+    import jupyterhub.tests.mocking as hub_mocking
+except ImportError:
+    hub_mocking = None
 
 
 KEYTAB_PATH = "/home/dask/dask.keytab"
@@ -124,9 +128,9 @@ class temp_hub(object):
         type(self.hub).clear_instance()
 
 
+@pytest.mark.skipif(not hub_mocking, reason="JupyterHub not installed")
 @pytest.mark.asyncio
 async def test_jupyterhub_auth(tmpdir, monkeypatch):
-    hub_mocking = pytest.importorskip("jupyterhub.tests.mocking")
     from jupyterhub.tests.utils import add_user
 
     gateway_address = "http://127.0.0.1:%d" % random_port()

--- a/tests/test_local_cluster.py
+++ b/tests/test_local_cluster.py
@@ -4,9 +4,7 @@ from .utils import ClusterManagerTests, LocalTestingClusterManager
 
 
 class TestLocalClusterManager(ClusterManagerTests):
-    async def cleanup_cluster(
-        self, manager, cluster_info, cluster_state, worker_states
-    ):
+    async def cleanup_cluster(self, manager, cluster_state, worker_states):
         for state in worker_states + [cluster_state]:
             pid = state.get("pid")
             if pid is not None:
@@ -15,11 +13,11 @@ class TestLocalClusterManager(ClusterManagerTests):
     def new_manager(self, **kwargs):
         return LocalTestingClusterManager(**kwargs)
 
-    def cluster_is_running(self, manager, cluster_info, cluster_state):
+    async def cluster_is_running(self, manager, cluster_state):
         pid = cluster_state.get("pid")
         return is_running(pid) if pid is not None else False
 
-    def worker_is_running(self, manager, cluster_info, cluster_state, worker_state):
+    async def worker_is_running(self, manager, cluster_state, worker_state):
         pid = worker_state.get("pid")
         return is_running(pid) if pid is not None else False
 


### PR DESCRIPTION
We move back to using one `ClusterManager` per dask cluster. This
complicates some manager internals and simplifies others (now harder to
have shared state, easier to have per-cluster state, before it was the
opposite).

The reason for this switch is to add support for per-cluster
configuration (e.g. user overrides `worker_cores` for their cluster).
This will be added in a subsequent PR.