### PR TITLE
Allow users to configure clusters

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -13,6 +13,7 @@ pip install \
     pytest-asyncio \
     trustme \
     jupyterhub \
+    ipywidgets \
     notebook \
     black \
     flake8

--- a/dask-gateway-server/dask_gateway_server/handlers.py
+++ b/dask-gateway-server/dask_gateway_server/handlers.py
@@ -48,6 +48,9 @@ class BaseHandler(web.RequestHandler):
         else:
             self.json_data = None
 
+    def write_error(self, status_code, **kwargs):
+        self.finish({"error": self._reason})
+
     @property
     def authenticator(self):
         return self.settings.get("authenticator")
@@ -187,7 +190,7 @@ class ClustersHandler(BaseHandler):
                 try:
                     statuses = [ClusterStatus.from_name(k) for k in status.split(",")]
                 except Exception as exc:
-                    raise web.HTTPError(405, reason=str(exc))
+                    raise web.HTTPError(422, reason=str(exc))
                 select = lambda x: x.status in statuses
             out = {
                 k: cluster_model(self.gateway, v, full=False)
@@ -274,7 +277,7 @@ class ClusterScaleHandler(BaseHandler):
         try:
             total = self.json_data["worker_count"]
         except (TypeError, KeyError):
-            raise web.HTTPError(405)
+            raise web.HTTPError(422, reason="Malformed request body")
         await self.gateway.scale(cluster, total)
 
 

--- a/dask-gateway-server/dask_gateway_server/objects.py
+++ b/dask-gateway-server/dask_gateway_server/objects.py
@@ -128,6 +128,7 @@ clusters = Table(
         "user_id", Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     ),
     Column("status", IntEnum(ClusterStatus), nullable=False),
+    Column("options", JSON, nullable=False),
     Column("state", JSON, nullable=False),
     Column("token", BINARY(140), nullable=False, unique=True),
     Column("scheduler_address", Unicode(255), nullable=False),
@@ -317,7 +318,7 @@ class DataManager(object):
                 if cluster.is_active():
                     yield cluster
 
-    def create_cluster(self, user):
+    def create_cluster(self, user, options):
         """Create a new cluster for a user"""
         cluster_name = uuid.uuid4().hex
         token = uuid.uuid4().hex
@@ -328,6 +329,7 @@ class DataManager(object):
 
         common = {
             "name": cluster_name,
+            "options": options,
             "status": ClusterStatus.STARTING,
             "state": {},
             "scheduler_address": "",
@@ -413,6 +415,7 @@ class Cluster(object):
         name=None,
         user=None,
         token=None,
+        options=None,
         status=None,
         state=None,
         scheduler_address="",
@@ -427,6 +430,7 @@ class Cluster(object):
         self.name = name
         self.user = user
         self.token = token
+        self.options = options
         self.status = status
         self.state = state
         self.scheduler_address = scheduler_address

--- a/dask-gateway-server/dask_gateway_server/objects.py
+++ b/dask-gateway-server/dask_gateway_server/objects.py
@@ -215,6 +215,7 @@ class DataManager(object):
                 name=c.name,
                 user=user,
                 token=token,
+                options=c.options,
                 status=c.status,
                 state=c.state,
                 scheduler_address=c.scheduler_address,

--- a/dask-gateway-server/dask_gateway_server/options.py
+++ b/dask-gateway-server/dask_gateway_server/options.py
@@ -1,0 +1,238 @@
+from collections import OrderedDict
+from keyword import iskeyword
+
+
+__all__ = ("Options", "String", "Bool", "Integer", "Float", "MemoryLimit", "Select")
+
+
+# A singleton indicating no default value
+no_default = type(
+    "no_default",
+    (object,),
+    dict.fromkeys(["__repr__", "__reduce__"], lambda s: "no_default"),
+)()
+
+
+class AttrDict(dict):
+    """A dict that also allows attribute access for keys"""
+
+    def __getattr__(self, k):
+        if k in self:
+            return self[k]
+        raise AttributeError(k)
+
+    def __dir__(self):
+        out = set(type(self))
+        out.update(k for k in self if k.isidentifier() and not iskeyword(k))
+        return list(out)
+
+
+class Options(object):
+    """A description of cluster options.
+
+    Parameters
+    ----------
+    *fields : Field
+        Zero or more configurable fields.
+    handler : callable, optional
+        A callable with the signature ``handler(options)``, where ``options``
+        is the validated dict of user options. Should return a dict of
+        configuration overrides to forward to the cluster manager. If not
+        provided, the default will return the options unchanged.
+    """
+
+    def __init__(self, *fields, handler=None):
+        for f in fields:
+            if not isinstance(f, Field):
+                raise TypeError(
+                    "All fields must by instances of ``Field``, got %r"
+                    % type(f).__name__
+                )
+        self.fields = fields
+        self.handler = handler
+
+    def get_specification(self):
+        return [f.json_spec() for f in self.fields]
+
+    def parse_options(self, request):
+        if not isinstance(request, dict):
+            raise TypeError("options must be a dict, got %r" % type(request).__name__)
+        # Check for extra fields
+        extra = set(request).difference(f.field for f in self.fields)
+        if extra:
+            raise ValueError("Unknown fields %r" % extra)
+        # Validate and normalize options
+        options = {}
+        for f in self.fields:
+            if f.field in request:
+                options[f.field] = f.validate(request[f.field])
+            elif f.default is not no_default:
+                options[f.field] = f.default
+            else:
+                raise ValueError("must specify value for %r" % f.field)
+        return options
+
+    def get_configuration(self, options):
+        if self.handler is None:
+            return options
+        return self.handler(AttrDict(options))
+
+
+class Field(object):
+    def __init__(self, field, default=no_default, target=None, label=None):
+        self.field = field
+        if default is not no_default:
+            default = self.validate(default)
+        self.default = default
+        if target is None:
+            target = field
+        self.target = target
+        self.label = label
+
+    def json_spec(self):
+        out = {"field": self.field}
+        if self.default is not no_default:
+            out["default"] = self.default
+        if self.label is not None:
+            out["label"] = self.label
+        out["spec"] = self.json_type_spec()
+        return out
+
+    def json_type_spec(self):
+        raise NotImplementedError
+
+    def validate(self, x):
+        raise NotImplementedError
+
+
+class String(Field):
+    def validate(self, x):
+        if not isinstance(x, str):
+            raise TypeError("%s must be a string, got %r" % (self.field, x))
+        return x
+
+    def json_type_spec(self):
+        return {"type": "string"}
+
+
+class Bool(Field):
+    def __init__(self, field, default=False, label=None):
+        super().__init__(field, default=default, label=label)
+
+    def validate(self, x):
+        if not isinstance(x, bool):
+            raise TypeError("%s must be a bool, got %r" % (self.field, x))
+        return x
+
+    def json_type_spec(self):
+        return {"type": "bool"}
+
+
+class Number(Field):
+    def __init__(self, field, default=no_default, label=None, min=None, max=None):
+        # Temporarily set to allow `validate` to work
+        self.min = self.max = None
+        if min is not None:
+            self.min = self.validate(min)
+        if max is not None:
+            self.max = self.validate(max)
+        super().__init__(field, default=default, label=label)
+
+    def validate(self, x):
+        if self.min is not None and x < self.min:
+            raise ValueError("%s must be >= %f, got %s" % (self.field, self.min, x))
+        if self.max is not None and x > self.max:
+            raise ValueError("%s must be <= %f, got %s" % (self.field, self.max, x))
+        return x
+
+
+class Integer(Number):
+    def validate(self, x):
+        if not isinstance(x, int):
+            raise TypeError("%s must be an integer, got %r" % (self.field, x))
+        return super().validate(x)
+
+    def json_type_spec(self):
+        return {"type": "int", "min": self.min, "max": self.max}
+
+
+class Float(Number):
+    def validate(self, x):
+        if isinstance(x, int):
+            x = float(x)
+        if not isinstance(x, float):
+            raise TypeError("%s must be a float, got %r" % (self.field, x))
+        return super().validate(x)
+
+    def json_type_spec(self):
+        return {"type": "float", "min": self.min, "max": self.max}
+
+
+class MemoryLimit(Integer):
+    """A specification of a memory limit, with optional units.
+
+    Supported units are:
+      - K -> Kibibytes
+      - M -> Mebibytes
+      - G -> Gibibytes
+      - T -> Tebibytes
+    """
+
+    UNIT_SUFFIXES = {"K": 2 ** 10, "M": 2 ** 20, "G": 2 ** 30, "T": 2 ** 40}
+
+    _error_template = (
+        "{field} must be a valid memory specification, got {value}. Expected an "
+        "int or a string with suffix K, M, G, T"
+    )
+
+    def validate(self, value):
+        if isinstance(value, (int, float)):
+            return int(value)
+
+        try:
+            num = float(value[:-1])
+        except ValueError:
+            raise ValueError(self._error_template.format(field=self.field, value=value))
+        suffix = value[-1]
+
+        if suffix not in self.UNIT_SUFFIXES:
+            raise ValueError(self._error_template.format(field=self.field, value=value))
+        return int(float(num) * self.UNIT_SUFFIXES[suffix])
+
+    def json_type_spec(self):
+        return {"type": "memory", "min": self.min, "max": self.max}
+
+
+class Select(Field):
+    def __init__(self, field, options=None, default=no_default, label=None):
+        if options is None:
+            raise ValueError("Must provide at least one option")
+        elif not isinstance(options, list):
+            raise TypeError("options must be a list")
+        options_map = OrderedDict()
+        for value in options:
+            if isinstance(value, tuple):
+                label, value = value
+                label = str(label)
+            else:
+                label = str(value)
+            options_map[label] = value
+
+        if default is not no_default:
+            default = str(default)
+            if default not in self.options_map:
+                raise ValueError("default %r not in options" % default)
+
+        self.options = options_map
+        super().__init__(field, default=default, label=label)
+
+    def validate(self, x):
+        if not isinstance(x, str):
+            raise TypeError("%s must be a string, got %r" % (self.field, x))
+        try:
+            return self.options[x]
+        except KeyError:
+            raise ValueError("%r is not a valid option for %s" % (x, self.field))
+
+    def json_type_spec(self):
+        return {"type": "select", "options": list(self.options)}

--- a/dask-gateway-server/dask_gateway_server/options.py
+++ b/dask-gateway-server/dask_gateway_server/options.py
@@ -232,11 +232,11 @@ class Float(Number):
     description="An option field asking users to select between a few choices.",
     params="""
     options : list
-        A list of valid options. Elements may be a tuple of ``(label, value)``,
-        or just ``label`` (in which case the value is the same as the label).
-        Values may be any Python object, labels must be strings.
+        A list of valid options. Elements may be a tuple of ``(key, value)``,
+        or just ``key`` (in which case the value is the same as the key).
+        Values may be any Python object, keys must be strings.
     default : str, optional
-        The label for the default option. Defaults to the first listed option.
+        The key for the default option. Defaults to the first listed option.
     """,
 )
 class Select(Field):
@@ -246,21 +246,15 @@ class Select(Field):
         options_map = OrderedDict()
         for value in options:
             if isinstance(value, tuple):
-                label, value = value
+                key, value = value
             else:
-                label = str(value)
-            if not isinstance(label, str):
-                raise TypeError("Select labels must be strings, got %r" % label)
-            options_map[label] = value
+                key = str(value)
+            if not isinstance(key, str):
+                raise TypeError("Select keys must be strings, got %r" % key)
+            options_map[key] = value
 
-        if default is not None:
-            if not isinstance(default, str):
-                raise TypeError("Select default must be a string, got %r" % label)
-            if default not in self.options_map:
-                raise ValueError("default %r not in options" % default)
-        else:
-            # Default to the first option
-            default = list(self.options_map)[0]
+        if default is None:
+            default = list(options_map)[0]
 
         self.options = options_map
         super().__init__(field, default=default, label=label, target=target)

--- a/dask-gateway/dask_gateway/__init__.py
+++ b/dask-gateway/dask_gateway/__init__.py
@@ -1,5 +1,6 @@
 from .client import Gateway, GatewayCluster
 from .auth import KerberosAuth, BasicAuth
+from .options import Options
 
 # Load configuration
 from . import config

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -342,7 +342,7 @@ class Gateway(object):
 
         Returns
         -------
-        cluster_options : dict
+        cluster_options : Options
             A dict of cluster options.
         """
         return self.sync(self._cluster_options, **kwargs)

--- a/dask-gateway/dask_gateway/options.py
+++ b/dask-gateway/dask_gateway/options.py
@@ -1,0 +1,318 @@
+import weakref
+from collections import OrderedDict
+from collections.abc import MutableMapping
+from keyword import iskeyword
+
+
+__all__ = ("Options",)
+
+
+_field_types = {}
+
+
+def register_field_type(name):
+    def inner(cls):
+        _field_types[name] = cls
+        return cls
+
+    return inner
+
+
+class Options(MutableMapping):
+    """Options to submit to dask-gateway.
+
+    A mutable-mapping that describes all cluster options available for user's
+    to set. Options can be modified programatically, or via a widget when using
+    a web interface (e.g. Jupyter Notebooks) with ``ipywidgets`` installed.
+
+    Examples
+    --------
+    Options objects are normally created via the ``Gateway.cluster_options``
+    method:
+
+    >>> options = gateway.cluster_options()  # doctest: +SKIP
+
+    Available options can then be accessed or set via attribute or key:
+
+    >>> options.worker_cores  # doctest: +SKIP
+    1
+    >>> options["worker_cores"]  # doctest: +SKIP
+    1
+    >>> options.worker_cores = 2  # doctest: +SKIP
+    >>> options.worker_cores  # doctest: +SKIP
+    2
+
+    Accessing invalid options error appropriately:
+
+    >>> options.not_a_valid_option = 'myvalue'  # doctest: +SKIP
+    Traceback (most recent call last):
+        ...
+    AttributeError: No option 'not_a_valid_option' available
+
+    Errors are also raised if values being set are invalid (e.g. wrong type,
+    out-of-bounds, etc...).
+    """
+
+    def __init__(self, *fields):
+        object.__setattr__(self, "_fields", OrderedDict((f.field, f) for f in fields))
+
+    @classmethod
+    def _from_spec(cls, spec):
+        fields = []
+        for item in spec:
+            field = item["field"]
+            default = item["default"]
+            label = item.get("label")
+            spec = item["spec"]
+            typ = spec.pop("type")
+
+            fields.append(_field_types[typ](field, default, label=label, **spec))
+        return cls(*fields)
+
+    def _widget(self):
+        if not hasattr(self, "_cached_widget"):
+            try:
+                import ipywidgets
+
+                children = [ipywidgets.HTML("<h2>Cluster Options</h2>")]
+                children.extend([f.widget() for f in self._fields.values()])
+                column = ipywidgets.Box(
+                    children=children,
+                    layout=ipywidgets.Layout(
+                        display="flex", flex_flow="column", align_items="stretch"
+                    ),
+                )
+                widget = ipywidgets.Box(children=[column])
+            except ImportError:
+                widget = None
+            object.__setattr__(self, "_cached_widget", widget)
+        return self._cached_widget
+
+    def _ipython_display_(self, **kwargs):
+        widget = self._widget()
+        if widget is not None:
+            return widget._ipython_display_(**kwargs)
+        from IPython.lib.pretty import pprint
+
+        pprint(self)
+
+    def _repr_pretty_(self, p, cycle):
+        if cycle:
+            p.text("Options<...>")
+        else:
+            with p.group(8, "Options<", ">"):
+                for idx, field in enumerate(self._fields.values()):
+                    if idx:
+                        p.text(",")
+                        p.breakable()
+                    p.text("%s=" % field.field)
+                    p.pretty(field.value)
+
+    def _get(self, key, exc_cls):
+        try:
+            return self._fields[key].get()
+        except KeyError:
+            raise exc_cls("No option %r available" % key) from None
+
+    def _set(self, key, value, exc_cls):
+        try:
+            self._fields[key].set(value)
+        except KeyError:
+            raise exc_cls("No option %r available" % key) from None
+
+    def __getattr__(self, key):
+        return self._get(key, AttributeError)
+
+    def __setattr__(self, key, value):
+        return self._set(key, value, AttributeError)
+
+    def __getitem__(self, key):
+        return self._get(key, KeyError)
+
+    def __setitem__(self, key, value):
+        return self._set(key, value, KeyError)
+
+    def __delitem__(self, key):
+        raise TypeError("Cannot delete fields")
+
+    def __iter__(self):
+        return iter(self._fields)
+
+    def __len__(self):
+        return len(self._fields)
+
+    def __dir__(self):
+        o = set(dir(type(self)))
+        o.update(self.__dict__)
+        o.update(f for f in self._fields if f.isidentifier() and not iskeyword(f))
+        return list(o)
+
+
+class Field(object):
+    """A single option field"""
+
+    def __init__(self, field, default, label=None):
+        self.field = field
+        self.value = self.validate(default)
+        self.label = label or field
+
+        self._widgets = weakref.WeakSet()
+
+    def validate(self, x):
+        raise NotImplementedError
+
+    def set(self, value):
+        self.value = self.validate(value)
+        # Update all linked widgets
+        for w in self._widgets:
+            w.value = self.value
+
+    def get(self):
+        return self.value
+
+    def widget(self):
+        import ipywidgets
+
+        def handler(change):
+            self.set(change.new)
+
+        input = self._widget()
+        input.observe(handler, "value")
+        self._widgets.add(input)
+
+        label = ipywidgets.HTML(
+            "<p style='font-weight: bold; margin-right: 8px'>%s:</p>" % self.label
+        )
+
+        row = ipywidgets.Box(
+            children=[label, input],
+            layout=ipywidgets.Layout(
+                display="flex", flex_flow="row wrap", justify_content="space-between"
+            ),
+        )
+
+        return row
+
+
+@register_field_type("string")
+class String(Field):
+    """A string option field"""
+
+    def validate(self, x):
+        if not isinstance(x, str):
+            raise TypeError("%s must be a string, got %r" % (self.field, x))
+        return x
+
+    def _widget(self):
+        import ipywidgets
+
+        return ipywidgets.Text(value=self.value, continuous_update=False)
+
+
+@register_field_type("bool")
+class Bool(Field):
+    """A boolean option field"""
+
+    def validate(self, x):
+        if not isinstance(x, bool):
+            raise TypeError("%s must be a bool, got %r" % (self.field, x))
+        return x
+
+    def _widget(self):
+        import ipywidgets
+
+        return ipywidgets.Checkbox(value=self.value, indent=False)
+
+
+class Number(Field):
+    def __init__(self, field, default, label=None, min=None, max=None):
+        # Temporarily set to allow `validate` to work
+        self.min = self.max = None
+        if min is not None:
+            self.min = self.validate(min)
+        if max is not None:
+            self.max = self.validate(max)
+        super().__init__(field, default, label=label)
+
+    def validate(self, x):
+        if self.min is not None and x < self.min:
+            raise ValueError("%s must be >= %f, got %s" % (self.field, self.min, x))
+        if self.max is not None and x > self.max:
+            raise ValueError("%s must be <= %f, got %s" % (self.field, self.max, x))
+        return x
+
+
+@register_field_type("int")
+class Integer(Number):
+    """An integer option field"""
+
+    def validate(self, x):
+        if not isinstance(x, int):
+            raise TypeError("%s must be an integer, got %r" % (self.field, x))
+        return super().validate(x)
+
+    def _widget(self):
+        import ipywidgets
+
+        if self.min is None and self.max is None:
+            return ipywidgets.IntText(value=self.value)
+        else:
+            return ipywidgets.BoundedIntText(
+                value=self.value,
+                min=self.min or -(2 ** 63),
+                max=self.max or (2 ** 63 - 1),
+            )
+
+
+@register_field_type("float")
+class Float(Number):
+    """A float option field"""
+
+    def validate(self, x):
+        if isinstance(x, int):
+            x = float(x)
+        if not isinstance(x, float):
+            raise TypeError("%s must be a float, got %r" % (self.field, x))
+        return super().validate(x)
+
+    def _widget(self):
+        import ipywidgets
+
+        if self.min is None and self.max is None:
+            return ipywidgets.FloatText(value=self.value, step=0.1)
+        else:
+            return ipywidgets.BoundedFloatText(
+                value=self.value,
+                step=0.1,
+                min=self.min or float("-inf"),
+                max=self.max or float("inf"),
+            )
+
+
+@register_field_type("select")
+class Select(Field):
+    """A select option field"""
+
+    def __init__(self, field, default, label=None, options=None):
+        if options is None:
+            raise ValueError("Must provide at least one option")
+        elif not isinstance(options, list):
+            raise TypeError("options must be a list")
+        for o in options:
+            if not isinstance(o, str):
+                raise TypeError("options must be strings")
+        self.options = options
+        self._options_set = set(options)
+        super().__init__(field, default, label=label)
+
+    def validate(self, x):
+        if not isinstance(x, str):
+            raise TypeError("%s must be a string, got %r" % (self.field, x))
+        if x not in self._options_set:
+            raise ValueError("%r is not a valid option for %s" % (x, self.field))
+        return x
+
+    def _widget(self):
+        import ipywidgets
+
+        return ipywidgets.Dropdown(value=self.value, options=self.options)

--- a/docs/source/api-client.rst
+++ b/docs/source/api-client.rst
@@ -4,9 +4,21 @@ Client API
 .. currentmodule:: dask_gateway
 
 
+Gateway
+-------
+
 .. autoclass:: Gateway
     :members:
 
 
+GatewayCluster
+--------------
+
 .. autoclass:: GatewayCluster
     :members:
+
+
+Options
+-------
+
+.. autoclass:: dask_gateway.options.Options

--- a/docs/source/api-server.rst
+++ b/docs/source/api-server.rst
@@ -7,6 +7,22 @@ Gateway
 .. autoconfigurable:: dask_gateway_server.app.DaskGateway
 
 
+Cluster Manager Options
+-----------------------
+
+.. autoclass:: dask_gateway_server.options.Options
+
+.. autoclass:: dask_gateway_server.options.Integer
+
+.. autoclass:: dask_gateway_server.options.Float
+
+.. autoclass:: dask_gateway_server.options.String
+
+.. autoclass:: dask_gateway_server.options.Bool
+
+.. autoclass:: dask_gateway_server.options.Select
+
+
 Proxies
 -------
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -26,9 +26,11 @@ def check_consistency(db):
     for c in clusters:
         cluster = db.id_to_cluster[c.id]
         assert db.token_to_cluster[db.decode_token(c.token)] is cluster
+        assert db.name_to_cluster[c.name] is cluster
         user = id_to_user[c.user_id]
         assert user.clusters[c.name] is cluster
     assert len(db.id_to_cluster) == len(clusters)
+    assert len(db.name_to_cluster) == len(clusters)
     assert len(db.token_to_cluster) == len(clusters)
 
     # Check worker state
@@ -58,7 +60,7 @@ async def test_cleanup_expired_clusters(monkeypatch):
     monkeypatch.setattr(time, "time", mytime)
 
     def add_cluster(stop=True):
-        c = db.create_cluster(alice)
+        c = db.create_cluster(alice, {})
         for _ in range(5):
             w = db.create_worker(c)
             if stop:
@@ -123,7 +125,7 @@ async def test_encryption(tmpdir):
     assert data == data2
 
     alice = db.get_or_create_user("alice")
-    c = db.create_cluster(alice)
+    c = db.create_cluster(alice, {})
     assert c.tls_cert is not None
     assert c.tls_key is not None
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,482 @@
+import pytest
+
+import dask_gateway.options as client_options
+import dask_gateway_server.options as server_options
+from dask_gateway_server.options import FrozenAttrDict
+
+
+def test_string():
+    field = "field_name"
+    default = "default_value"
+    target = "target_name"
+    label = "Field Name"
+
+    # Default values
+    s_opt = server_options.String(field)
+    assert s_opt.default == ""
+    assert s_opt.label == field
+    assert s_opt.target == field
+
+    # Specified values propogate
+    s_opt = server_options.String(field, default=default, target=target, label=label)
+    assert s_opt.default == default
+    assert s_opt.target == target
+    assert s_opt.label == label
+
+    def check(opt):
+        assert opt.validate("hello") == "hello"
+
+        with pytest.raises(TypeError):
+            opt.validate(1)
+
+    # Server-side validation
+    check(s_opt)
+
+    # Serialization works
+    spec = s_opt.json_spec()
+
+    c_opt = client_options.Field._from_spec(spec)
+
+    assert isinstance(c_opt, client_options.String)
+    assert c_opt.value == default
+    assert c_opt.label == label
+
+    # Client-side validation
+    check(c_opt)
+
+
+def test_bool():
+    field = "field_name"
+    default = True
+    target = "target_name"
+    label = "Field Name"
+
+    # Default values
+    s_opt = server_options.Bool(field)
+    assert s_opt.default is False
+    assert s_opt.label == field
+    assert s_opt.target == field
+
+    # Specified values propogate
+    s_opt = server_options.Bool(field, default=default, target=target, label=label)
+    assert s_opt.default == default
+    assert s_opt.target == target
+    assert s_opt.label == label
+
+    def check(opt):
+        assert opt.validate(True) is True
+
+        with pytest.raises(TypeError):
+            opt.validate(1)
+
+    # Server-side validation
+    check(s_opt)
+
+    # Serialization works
+    spec = s_opt.json_spec()
+
+    c_opt = client_options.Field._from_spec(spec)
+
+    assert isinstance(c_opt, client_options.Bool)
+    assert c_opt.value == default
+    assert c_opt.label == label
+
+    # Client-side validation
+    check(c_opt)
+
+
+def test_int():
+    field = "field_name"
+    default = 10
+    target = "target_name"
+    label = "Field Name"
+    min = 10
+    max = 20
+
+    # Default values
+    s_opt = server_options.Integer(field)
+    assert s_opt.default == 0
+    assert s_opt.label == field
+    assert s_opt.target == field
+    assert s_opt.min is None
+    assert s_opt.max is None
+
+    # Specified values propogate
+    s_opt = server_options.Integer(
+        field, default=default, target=target, label=label, min=min, max=max
+    )
+    assert s_opt.default == default
+    assert s_opt.target == target
+    assert s_opt.label == label
+    assert s_opt.min == min
+    assert s_opt.max == max
+
+    def check(opt):
+        assert opt.validate(15) == 15
+        assert opt.validate(10) == 10
+        assert opt.validate(20) == 20
+
+        with pytest.raises(TypeError):
+            opt.validate("1")
+        with pytest.raises(ValueError):
+            opt.validate(min - 1)
+        with pytest.raises(ValueError):
+            opt.validate(max + 1)
+
+    # Server-side validation
+    check(s_opt)
+
+    # Serialization works
+    spec = s_opt.json_spec()
+
+    c_opt = client_options.Field._from_spec(spec)
+
+    assert isinstance(c_opt, client_options.Integer)
+    assert c_opt.value == default
+    assert c_opt.label == label
+    assert s_opt.min == min
+    assert s_opt.max == max
+
+    # Client-side validation
+    check(c_opt)
+
+
+def test_float():
+    field = "field_name"
+    default = 10.0
+    target = "target_name"
+    label = "Field Name"
+    min = 10
+    max = 20
+
+    # Default values
+    s_opt = server_options.Float(field)
+    assert s_opt.default == 0
+    assert s_opt.label == field
+    assert s_opt.target == field
+    assert s_opt.min is None
+    assert s_opt.max is None
+
+    # Specified values propogate
+    s_opt = server_options.Float(
+        field, default=default, target=target, label=label, min=min, max=max
+    )
+    assert s_opt.default == default
+    assert s_opt.target == target
+    assert s_opt.label == label
+    assert s_opt.min == min
+    assert s_opt.max == max
+    assert isinstance(s_opt.min, float)
+    assert isinstance(s_opt.max, float)
+    assert isinstance(s_opt.default, float)
+
+    def check(opt):
+        assert opt.validate(15.5) == 15.5
+        assert opt.validate(10) == 10.0
+        assert opt.validate(20) == 20.0
+
+        with pytest.raises(TypeError):
+            opt.validate("1")
+        with pytest.raises(ValueError):
+            opt.validate(min - 1)
+        with pytest.raises(ValueError):
+            opt.validate(max + 1)
+
+    # Server-side validation
+    check(s_opt)
+
+    # Serialization works
+    spec = s_opt.json_spec()
+
+    c_opt = client_options.Field._from_spec(spec)
+
+    assert isinstance(c_opt, client_options.Float)
+    assert c_opt.value == default
+    assert c_opt.label == label
+    assert s_opt.min == min
+    assert s_opt.max == max
+
+    # Client-side validation
+    check(c_opt)
+
+
+def test_select():
+    field = "field_name"
+    default = "banana"
+    options = ["apple", "banana", ("orange", 1)]
+    target = "target_name"
+    label = "Field Name"
+
+    # Default values
+    s_opt = server_options.Select(field, options)
+    assert s_opt.default == "apple"
+    assert s_opt.label == field
+    assert s_opt.target == field
+
+    # Specified values propogate
+    s_opt = server_options.Select(
+        field, options, default=default, target=target, label=label
+    )
+    assert s_opt.default == default
+    assert s_opt.target == target
+    assert s_opt.label == label
+
+    def check(opt):
+        assert opt.validate("apple") == "apple"
+        assert opt.validate("orange") == "orange"
+
+        with pytest.raises(TypeError):
+            opt.validate(1)
+        with pytest.raises(ValueError):
+            opt.validate("grape")
+
+    # Server-side validation
+    check(s_opt)
+
+    # Bad server-side constructors
+    with pytest.raises(TypeError):
+        server_options.Select(field, 1)
+
+    with pytest.raises(TypeError):
+        server_options.Select(field, [1, 2, 3])
+
+    with pytest.raises(ValueError):
+        server_options.Select(field, [])
+
+    # Serialization works
+    spec = s_opt.json_spec()
+
+    c_opt = client_options.Field._from_spec(spec)
+
+    assert isinstance(c_opt, client_options.Select)
+    assert c_opt.value == default
+    assert c_opt.options == ("apple", "banana", "orange")
+    assert c_opt.label == label
+
+    # Client-side validation
+    check(c_opt)
+
+    # Bad client-side constructors
+    with pytest.raises(TypeError):
+        client_options.Select(field, default, options=1)
+
+    with pytest.raises(TypeError):
+        client_options.Select(field, default, options=[1, 2, 3])
+
+    with pytest.raises(ValueError):
+        client_options.Select(field, default, options=[])
+
+
+def test_frozen_attr_dict():
+    d = {"valid": 1, "not valid": 2, "for": 3}
+    ad = FrozenAttrDict(d)
+
+    # getattr
+    assert ad.valid == 1
+    with pytest.raises(AttributeError):
+        ad.missing
+
+    # getitem
+    assert ad["not valid"] == 2
+
+    # setattr
+    with pytest.raises(Exception):
+        ad.valid = 1
+
+    # setitem
+    with pytest.raises(TypeError):
+        ad["valid"] = 1
+
+    # len
+    assert len(ad) == len(d)
+
+    # iter
+    assert list(ad) == list(d)
+
+    # coversion
+    assert dict(ad) == d
+
+    # dir
+    tabs = dir(ad)
+    assert "valid" in tabs
+    assert "not valid" not in tabs
+    assert "for" not in tabs
+
+
+@pytest.fixture
+def server_opts():
+    return server_options.Options(
+        server_options.Integer("integer_field", 1, target="integer_field2"),
+        server_options.Float("float_field", 2.5, min=2, max=4),
+        server_options.Select("select_field", [("a", 5), "b", ("c", 10)]),
+    )
+
+
+def test_server_options_get_specification(server_opts):
+    spec = server_opts.get_specification()
+    c_opts = client_options.Options._from_spec(spec)
+    assert set(c_opts) == {"integer_field", "float_field", "select_field"}
+
+
+def test_server_options_parse_options(server_opts):
+    res = server_opts.parse_options({})
+    assert res == {"integer_field": 1, "float_field": 2.5, "select_field": "a"}
+
+    res = server_opts.parse_options({"select_field": "c", "float_field": 3})
+    assert res == {"integer_field": 1, "float_field": 3.0, "select_field": "c"}
+
+    with pytest.raises(TypeError):
+        server_opts.parse_options(None)
+
+    with pytest.raises(ValueError):
+        server_opts.parse_options({"extra1": 1, "extra2": 2, "integer_field": 3})
+
+
+def test_server_options_get_configuration(server_opts):
+    options = {"integer_field": 2}
+    sol = {"integer_field2": 2, "float_field": 2.5, "select_field": 5}
+
+    # Default handler
+    config = server_opts.get_configuration(options)
+    assert config == sol
+
+    # Custom handler
+    def handler(options):
+        assert isinstance(options, FrozenAttrDict)
+        assert dict(options) == sol
+        return {"a": 1}
+
+    server_opts.handler = handler
+    assert server_opts.get_configuration(options) == {"a": 1}
+
+
+@pytest.fixture
+def client_opts():
+    return client_options.Options(
+        client_options.Integer("worker_cores", 1, min=1, max=4, label="Worker Cores"),
+        client_options.Float(
+            "worker_memory", 1, min=1, max=8, label="Worker Memory (GB)"
+        ),
+        client_options.Integer("scheduler_cores", 1, label="Scheduler Cores"),
+        client_options.Float("scheduler_memory", 1, label="Scheduler Memory (GB)"),
+        client_options.Select(
+            "environment", "basic", options=["basic", "ml"], label="Conda Environment"
+        ),
+        client_options.Bool("keep_logs", False, label="Keep Logs"),
+        client_options.String("queue", "default", label="Queue"),
+    )
+
+
+def get_widget_for_field(options, field):
+    pytest.importorskip("ipywidgets")
+
+    widget = options._widget()
+    for n, f in enumerate(options._fields):
+        if f == field:
+            break
+    else:
+        raise ValueError("No field %s" % field)
+    # This is fragile to the formatting of the widgets
+    return widget.children[0].children[n + 1].children[1]
+
+
+def test_client_options(client_opts):
+    # Key and attribute access works
+    client_opts.worker_cores = 2
+    assert client_opts.worker_cores == 2
+    client_opts["worker_cores"] = 1
+    assert client_opts.worker_cores == 1
+
+    # Cannot delete options
+    with pytest.raises(TypeError):
+        del client_opts.worker_cores
+
+    with pytest.raises(TypeError):
+        del client_opts["worker_cores"]
+
+    # Cannot get/set unknown options
+    with pytest.raises(AttributeError):
+        client_opts.unknown
+    with pytest.raises(AttributeError):
+        client_opts.unknown = 1
+
+    with pytest.raises(KeyError):
+        client_opts["unknown"]
+    with pytest.raises(KeyError):
+        client_opts["unknown"] = 1
+
+    # Values are type checked
+    with pytest.raises(TypeError):
+        client_opts.worker_cores = 1.5
+    assert client_opts.worker_cores == 1
+
+    with pytest.raises(ValueError):
+        client_opts.environment = "unknown"
+    assert client_opts.environment == "basic"
+
+    # Tab completion works
+    tabs = dir(client_opts)
+    assert "worker_cores" in tabs
+    assert "queue" in tabs
+
+    # Other mapping methods
+    assert len(client_opts) == len(client_opts._fields)
+    assert len(dict(client_opts)) == len(client_opts._fields)
+
+
+def test_client_options_pretty_printing(client_opts):
+    pretty = pytest.importorskip("IPython.lib.pretty")
+
+    res = pretty.pretty(client_opts)
+    assert "worker_cores" in res
+    assert "Options<" in res
+
+
+def test_client_options_widget(client_opts):
+    ipywidgets = pytest.importorskip("ipywidgets")
+
+    widget = client_opts._widget()
+    assert isinstance(widget, ipywidgets.Box)
+
+    # widget is cached
+    assert widget is client_opts._widget()
+
+
+def check_opt_widget(opts, field, val1, val2, *bad_values):
+    widget = get_widget_for_field(opts, field)
+    assert widget.value == getattr(opts, field)
+    # widget to opts
+    widget.value = val1
+    assert getattr(opts, field) == val1
+    # opts to widget
+    setattr(opts, field, val2)
+    assert widget.value == val2
+
+    for val in bad_values:
+        with pytest.raises(Exception):
+            setattr(opts, field, val)
+        # Unchanged
+        assert getattr(opts, field) == val2
+        assert widget.value == val2
+
+
+def test_client_bool_widget(client_opts):
+    check_opt_widget(client_opts, "keep_logs", True, False, "bad value")
+
+
+def test_client_string_widget(client_opts):
+    check_opt_widget(client_opts, "queue", "queue-one", "queue-two", 1)
+
+
+def test_client_select_widget(client_opts):
+    check_opt_widget(client_opts, "environment", "ml", "basic", "unknown", 1)
+
+
+def test_client_integer_widget(client_opts):
+    check_opt_widget(client_opts, "worker_cores", 2, 3, 10, -1, "bad value")
+    check_opt_widget(client_opts, "scheduler_cores", 2, 3, "bad value")
+
+
+def test_client_float_widget(client_opts):
+    check_opt_widget(client_opts, "worker_memory", 2.5, 3.5, 100, -1, "bad value")
+    check_opt_widget(client_opts, "scheduler_memory", 2.5, 3.5, "bad value")


### PR DESCRIPTION
This adds a mechanism for specifying user configurable cluster
parameters in a declarative way. The set of configurable cluster
parameters (as well as useful metadata like input type/bounds/valid
values, etc...) are exposed via a rest api. This allows creation of nice
interactive GUIs on the client side without requiring client-side
configuration.