### PR TITLE
Python 3.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 language: python
 python:
-  - "3.7"
+  - "3.6"
 
 git:
   depth: false  # Ensure latest tag is pulled

--- a/dask-gateway-server/dask_gateway_server/compat.py
+++ b/dask-gateway-server/dask_gateway_server/compat.py
@@ -1,0 +1,8 @@
+# flake8: noqa
+
+import sys
+
+if sys.version_info[:2] >= (3, 7):
+    from asyncio import get_running_loop
+else:
+    from asyncio import _get_running_loop as get_running_loop

--- a/dask-gateway-server/dask_gateway_server/managers/kubernetes.py
+++ b/dask-gateway-server/dask_gateway_server/managers/kubernetes.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import threading
 import time
@@ -26,6 +25,7 @@ from urllib3.exceptions import ReadTimeoutError
 
 from .base import ClusterManager
 from .. import __version__ as VERSION
+from ..compat import get_running_loop
 from ..utils import MemoryLimit
 
 
@@ -77,7 +77,7 @@ class PodReflector(SingletonConfigurable):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.first_load_future = asyncio.get_running_loop().create_future()
+        self.first_load_future = get_running_loop().create_future()
         self.stopped = False
         self.start()
 
@@ -465,7 +465,7 @@ class KubeClusterManager(ClusterManager):
 
         self.log.debug("Creating secret %s", secret_name)
 
-        loop = asyncio.get_running_loop()
+        loop = get_running_loop()
         await loop.run_in_executor(
             None, self.kube_client.create_namespaced_secret, self.namespace, tls_secret
         )
@@ -518,7 +518,7 @@ class KubeClusterManager(ClusterManager):
         )
 
     async def stop_cluster(self, cluster_state):
-        loop = asyncio.get_running_loop()
+        loop = get_running_loop()
 
         pod_name = cluster_state.get("pod_name")
         if pod_name is not None:
@@ -542,7 +542,7 @@ class KubeClusterManager(ClusterManager):
 
         self.log.debug("Starting pod %s", pod.metadata.name)
 
-        loop = asyncio.get_running_loop()
+        loop = get_running_loop()
         await loop.run_in_executor(
             None, self.kube_client.create_namespaced_pod, self.namespace, pod
         )
@@ -552,7 +552,7 @@ class KubeClusterManager(ClusterManager):
     async def stop_worker(self, worker_name, worker_state, cluster_state):
         pod_name = worker_state.get("pod_name")
         if pod_name is not None:
-            loop = asyncio.get_running_loop()
+            loop = get_running_loop()
             await loop.run_in_executor(
                 None, self.kube_client.delete_namespaced_pod, pod_name, self.namespace
             )

--- a/dask-gateway-server/dask_gateway_server/objects.py
+++ b/dask-gateway-server/dask_gateway_server/objects.py
@@ -50,7 +50,7 @@ def normalize_encrypt_key(key):
     )
 
 
-class _EnumMixin(object):
+class _IntEnum(enum.IntEnum):
     @classmethod
     def from_name(cls, name):
         """Create an enum value from a name"""
@@ -61,7 +61,7 @@ class _EnumMixin(object):
         raise ValueError("%r is not a valid %s" % (name, cls.__name__))
 
 
-class ClusterStatus(_EnumMixin, enum.IntEnum):
+class ClusterStatus(_IntEnum):
     STARTING = 1
     STARTED = 2
     RUNNING = 3
@@ -70,7 +70,7 @@ class ClusterStatus(_EnumMixin, enum.IntEnum):
     FAILED = 6
 
 
-class WorkerStatus(_EnumMixin, enum.IntEnum):
+class WorkerStatus(_IntEnum):
     STARTING = 1
     STARTED = 2
     RUNNING = 3

--- a/dask-gateway-server/dask_gateway_server/objects.py
+++ b/dask-gateway-server/dask_gateway_server/objects.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.pool import StaticPool
 
+from .compat import get_running_loop
 from .tls import new_keypair
 
 
@@ -448,7 +449,7 @@ class Cluster(object):
         # The cluster manager instance
         self.manager = None
 
-        loop = asyncio.get_running_loop()
+        loop = get_running_loop()
         self.lock = asyncio.Lock(loop=loop)
         self._start_future = loop.create_future()
         self._connect_future = loop.create_future()
@@ -485,7 +486,7 @@ class Worker(object):
         self.start_time = start_time
         self.stop_time = stop_time
 
-        loop = asyncio.get_running_loop()
+        loop = get_running_loop()
 
         self._start_future = loop.create_future()
         self._connect_future = loop.create_future()

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -59,7 +59,7 @@ class GatewaySecurity(Security):
         return {"ssl_context": ctx}
 
 
-class _EnumMixin(object):
+class _IntEnum(enum.IntEnum):
     @classmethod
     def _create(cls, x):
         return x if isinstance(x, cls) else cls.from_name(x)
@@ -74,7 +74,7 @@ class _EnumMixin(object):
         raise ValueError("%r is not a valid %s" % (name, cls.__name__))
 
 
-class ClusterStatus(_EnumMixin, enum.IntEnum):
+class ClusterStatus(_IntEnum):
     """The cluster's status.
 
     Attributes

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -9,6 +9,7 @@ from traitlets.config import Config
 
 from dask_gateway import Gateway
 from dask_gateway_server.app import DaskGateway
+from dsak_gateway_server.compat import get_running_loop
 from dask_gateway_server.objects import ClusterStatus
 from dask_gateway_server.managers import ClusterManager
 from dask_gateway_server.managers.inprocess import InProcessClusterManager
@@ -77,7 +78,7 @@ class ClusterFailsAfterConnect(InProcessClusterManager):
 
     async def start_cluster(self):
         # Initiate state
-        loop = asyncio.get_running_loop()
+        loop = get_running_loop()
         self.failed = loop.create_future()
         self.stop_cluster_called = loop.create_future()
         # Start the cluster
@@ -151,7 +152,7 @@ class WorkerFailsBetweenStartAndConnect(InProcessClusterManager):
 class WorkerFailsAfterConnect(InProcessClusterManager):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        loop = asyncio.get_running_loop()
+        loop = get_running_loop()
         self.stop_worker_called = loop.create_future()
         self.worker_connected = loop.create_future()
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -9,7 +9,7 @@ from traitlets.config import Config
 
 from dask_gateway import Gateway
 from dask_gateway_server.app import DaskGateway
-from dsak_gateway_server.compat import get_running_loop
+from dask_gateway_server.compat import get_running_loop
 from dask_gateway_server.objects import ClusterStatus
 from dask_gateway_server.managers import ClusterManager
 from dask_gateway_server.managers.inprocess import InProcessClusterManager

--- a/tests/test_kubernetes_cluster.py
+++ b/tests/test_kubernetes_cluster.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import pytest
 
@@ -10,6 +9,7 @@ pytest.importorskip("kubernetes")
 import kubernetes.client
 from kubernetes.client.rest import ApiException
 
+from dsak_gateway_server.compat import get_running_loop
 from dask_gateway_server.managers.kubernetes import KubeClusterManager, PodReflector
 
 from .utils import ClusterManagerTests
@@ -64,7 +64,7 @@ class TestKubeClusterManager(ClusterManagerTests):
         secret_name = cluster_state.get("secret_name")
         if secret_name is not None:
             try:
-                loop = asyncio.get_running_loop()
+                loop = get_running_loop()
                 await loop.run_in_executor(
                     None,
                     manager.kube_client.delete_namespaced_secret,
@@ -77,7 +77,7 @@ class TestKubeClusterManager(ClusterManagerTests):
                 raise
 
     async def delete_pod(self, manager, pod_name):
-        loop = asyncio.get_running_loop()
+        loop = get_running_loop()
         if pod_name is not None:
             try:
                 await loop.run_in_executor(

--- a/tests/test_kubernetes_cluster.py
+++ b/tests/test_kubernetes_cluster.py
@@ -9,7 +9,7 @@ pytest.importorskip("kubernetes")
 import kubernetes.client
 from kubernetes.client.rest import ApiException
 
-from dsak_gateway_server.compat import get_running_loop
+from dask_gateway_server.compat import get_running_loop
 from dask_gateway_server.managers.kubernetes import KubeClusterManager, PodReflector
 
 from .utils import ClusterManagerTests

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -317,7 +317,10 @@ class ClusterManagerTests(object):
                 i += 1
 
         # Cleanup cancelled async generator
-        await start_task.athrow(GeneratorExit)
+        try:
+            await start_task.athrow(GeneratorExit)
+        except GeneratorExit:
+            pass
 
         # Assert not running
         assert not await self.cluster_status(cluster)
@@ -411,7 +414,10 @@ class ClusterManagerTests(object):
                 i += 1
 
         # Cleanup cancelled async generator
-        await start_task.athrow(GeneratorExit)
+        try:
+            await start_task.athrow(GeneratorExit)
+        except GeneratorExit:
+            pass
 
         # Assert not running
         assert not await self.worker_status(worker, cluster)


### PR DESCRIPTION
Enums with mixins aren't supported in Python 3.6, but subclasses are.
This fixes a python 3.6 compatibility error. We also now test with
python 3.6.