### PR TITLE
Better errors on import failure

### DIFF
--- a/dask-gateway-server/dask_gateway_server/app.py
+++ b/dask-gateway-server/dask_gateway_server/app.py
@@ -14,17 +14,7 @@ from tornado.log import LogFormatter
 from tornado.gen import IOLoop
 from tornado.platform.asyncio import AsyncIOMainLoop
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
-from traitlets import (
-    Unicode,
-    Bool,
-    Type,
-    Bytes,
-    Float,
-    List,
-    Instance,
-    default,
-    validate,
-)
+from traitlets import Unicode, Bool, Bytes, Float, List, Instance, default, validate
 from traitlets.config import Application, catch_config_error
 
 from . import __version__ as VERSION
@@ -41,7 +31,7 @@ from .objects import (
 )
 from .options import Options
 from .proxy import SchedulerProxy, WebProxy
-from .utils import cleanup_tmpdir, cancel_task, TaskPool, get_ip
+from .utils import cleanup_tmpdir, cancel_task, TaskPool, Type, get_ip
 
 
 # Override default values for logging

--- a/dask-gateway-server/dask_gateway_server/managers/kubernetes.py
+++ b/dask-gateway-server/dask_gateway_server/managers/kubernetes.py
@@ -5,6 +5,17 @@ import time
 from traitlets import Int, Float, List, Dict, Unicode, Instance, default
 from traitlets.config import SingletonConfigurable
 
+try:
+    import kubernetes
+except ImportError:
+    raise ImportError(
+        "'%s.KubeClusterManager' requires 'kubernetes' as a dependency. "
+        "To install required dependencies, use:\n"
+        "  $ pip install dask-gateway-server[kubernetes]\n"
+        "or\n"
+        "  $ conda install dask-gateway-server-kubernetes -c conda-forge\n" % __name__
+    )
+
 import kubernetes.client
 import kubernetes.config
 import kubernetes.watch

--- a/dask-gateway-server/dask_gateway_server/managers/yarn.py
+++ b/dask-gateway-server/dask_gateway_server/managers/yarn.py
@@ -3,7 +3,18 @@ import os
 from collections import OrderedDict
 from contextlib import contextmanager
 
-import skein
+try:
+    import skein
+except ImportError:
+    raise ImportError(
+        "'%s.YarnClusterManager' requires 'skein' as a dependency. "
+        "To install required dependencies, use:\n"
+        "  $ pip install dask-gateway-server[yarn]\n"
+        "or\n"
+        "  $ conda install dask-gateway-server-yarn -c conda-forge\n" % __name__
+    )
+
+
 from traitlets import Unicode, Dict, Set, Integer, Instance, Any
 from traitlets.config import SingletonConfigurable
 

--- a/dask-gateway-server/dask_gateway_server/utils.py
+++ b/dask-gateway-server/dask_gateway_server/utils.py
@@ -3,7 +3,7 @@ import shutil
 import socket
 import weakref
 
-from traitlets import Integer, TraitError
+from traitlets import Integer, TraitError, Type as _Type
 
 
 class TaskPool(object):
@@ -122,3 +122,18 @@ class MemoryLimit(Integer):
                 "a string with suffix K, M, G, T".format(val=value)
             )
         return int(float(num) * self.UNIT_SUFFIXES[suffix])
+
+
+class Type(_Type):
+    """An implementation of `Type` with better errors"""
+
+    def validate(self, obj, value):
+        if isinstance(value, str):
+            try:
+                value = self._resolve_string(value)
+            except ImportError as exc:
+                raise TraitError(
+                    "Failed to import %r for trait '%s.%s':\n\n%s"
+                    % (value, type(obj).__name__, self.name, exc)
+                )
+        return super().validate(obj, value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+import pytest
+from traitlets import HasTraits, TraitError
+
+from dask_gateway_server.utils import Type
+
+
+def test_Type_traitlet():
+    class Foo(HasTraits):
+        typ = Type(klass="dask_gateway_server.managers.ClusterManager")
+
+    with pytest.raises(TraitError) as exc:
+        Foo(typ="dask_gateway_server.managers.not_a_real_path")
+    assert "Failed to import" in str(exc.value)
+
+    Foo(typ="dask_gateway_server.managers.local.LocalClusterManager")


### PR DESCRIPTION
We override the ``Type`` traitlet to provide a better error message on
import error, and raise nice error messages for cluster managers that
have extra dependencies.

Fixes #58.