### PR TITLE
Cleanup client-side exceptions

### DIFF
--- a/dask-gateway-server/dask_gateway_server/handlers.py
+++ b/dask-gateway-server/dask_gateway_server/handlers.py
@@ -211,7 +211,8 @@ class ClustersHandler(BaseHandler):
             try:
                 await self.waiter
             except asyncio.CancelledError:
-                return
+                if self.waiter is None:
+                    return
         self.write(cluster_model(self.gateway, cluster, full=True))
 
     @user_authenticated
@@ -229,6 +230,7 @@ class ClustersHandler(BaseHandler):
     def on_connection_close(self):
         if hasattr(self, "waiter"):
             self.waiter.cancel()
+            self.waiter = None
 
 
 class ClusterRegistrationHandler(BaseHandler):

--- a/dask-gateway/dask_gateway/__init__.py
+++ b/dask-gateway/dask_gateway/__init__.py
@@ -1,4 +1,4 @@
-from .client import Gateway, GatewayCluster
+from .client import Gateway, GatewayCluster, GatewayClusterError, GatewayServerError
 from .auth import KerberosAuth, BasicAuth
 from .options import Options
 

--- a/docs/source/api-client.rst
+++ b/docs/source/api-client.rst
@@ -22,3 +22,11 @@ Options
 -------
 
 .. autoclass:: dask_gateway.options.Options
+
+
+Exceptions
+----------
+
+.. autoclass:: dask_gateway.GatewayClusterError
+
+.. autoclass:: dask_gateway.GatewayServerError


### PR DESCRIPTION
Switches to using specific error classes for client errors instead of
raw `Exception`.

Also fixes an issue where errors during cluster startup were being conflated
with `connect` long polling timeouts, resulting in poor exceptions
client-side. A test has been added for this code path.