### PR TITLE
Add _repr_html_ to cluster object

### DIFF
--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -711,4 +711,26 @@ class GatewayCluster(object):
         widget = self._widget()
         if widget is not None:
             return widget._ipython_display_(**kwargs)
-        print(self)
+        else:
+            from IPython.display import display
+
+            data = {"text/plain": repr(self), "text/html": self._repr_html_()}
+            display(data, raw=True)
+
+    def _repr_html_(self):
+        if self.dashboard_link is not None:
+            dashboard = "<a href='{0}' target='_blank'>{0}</a>".format(
+                self.dashboard_link
+            )
+        else:
+            dashboard = "Not Available"
+        return (
+            "<div style='background-color: #f2f2f2; display: inline-block; "
+            "padding: 10px; border: 1px solid #999999;'>\n"
+            "  <h3>GatewayCluster</h3>\n"
+            "  <ul>\n"
+            "    <li><b>Name: </b>{name}\n"
+            "    <li><b>Dashboard: </b>{dashboard}\n"
+            "  </ul>\n"
+            "</div>\n"
+        ).format(name=self.name, dashboard=dashboard)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -451,6 +451,9 @@ class temp_gateway(object):
             "public_url": "http://127.0.0.1:%d" % random_port(),
             "db_url": "sqlite:///:memory:",
             "authenticator_class": "dask_gateway_server.auth.DummyAuthenticator",
+            "cluster_manager_class": (
+                "dask_gateway_server.managers.inprocess.InProcessClusterManager"
+            ),
         }
         options.update(kwargs)
         config["DaskGateway"].update(options)


### PR DESCRIPTION
Adds support for standard HTML repr for the case where ipywidgets is not
installed.

If ipywidgets is installed, notebook reprs use the standard widgets. If not, notebook reprs look like the following:

- Dashboard running

<img width="1188" alt="Screen Shot 2019-07-31 at 6 14 57 PM" src="https://user-images.githubusercontent.com/2783717/62255232-e72c2200-b3c1-11e9-9f7f-32119b88d508.png">

- No dashboard running

<img width="463" alt="Screen Shot 2019-07-31 at 6 16 46 PM" src="https://user-images.githubusercontent.com/2783717/62255231-e6938b80-b3c1-11e9-817e-e28edae0ae8c.png">

This provides a nicer user experience for users without ipywidgets.