### PR TITLE
Specify proxy-address in Gateway client

### DIFF
--- a/dask-gateway-server/dask_gateway_server/handlers.py
+++ b/dask-gateway-server/dask_gateway_server/handlers.py
@@ -2,7 +2,7 @@ import asyncio
 import functools
 import json
 from inspect import isawaitable
-from urllib.parse import urlparse, unquote
+from urllib.parse import unquote
 
 from tornado import web
 from tornado.log import app_log
@@ -118,19 +118,12 @@ class BaseHandler(web.RequestHandler):
 
 
 def cluster_model(gateway, cluster, full=True):
-    if cluster.status == ClusterStatus.RUNNING:
-        scheduler = "gateway://%s/%s" % (
-            urlparse(gateway.gateway_url).netloc,
-            cluster.name,
-        )
-        dashboard = (
-            "/gateway/clusters/%s" % cluster.name if cluster.dashboard_address else ""
-        )
+    if cluster.status == ClusterStatus.RUNNING and cluster.dashboard_address:
+        dashboard = "/gateway/clusters/%s/status" % cluster.name
     else:
-        scheduler = dashboard = None
+        dashboard = None
     out = {
         "name": cluster.name,
-        "scheduler_address": scheduler,
         "dashboard_route": dashboard,
         "status": cluster.status.name,
         "start_time": cluster.start_time,

--- a/dask-gateway/dask_gateway/gateway.yaml
+++ b/dask-gateway/dask_gateway/gateway.yaml
@@ -1,9 +1,13 @@
 gateway:
-  address: null     # The full address to the dask-gateway server
+  address: null         # The full address to the dask-gateway server
+
+  proxy-address: 8786   # The full address or port to the dask-gateway
+                        # scheduler proxy. If a port, the host/ip is taken
+                        # from ``address``.
 
   auth:
-    type: basic     # The authentication type to use. Options are basic,
-                    # kerberos, or a full class path to a custom class.
+    type: basic         # The authentication type to use. Options are basic,
+                        # kerberos, or a full class path to a custom class.
 
-    kwargs: {}      # Keyword arguments to use when instantiating the
-                    # authentication class above.
+    kwargs: {}          # Keyword arguments to use when instantiating the
+                        # authentication class above.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -40,11 +40,12 @@ def kdestroy():
 @pytest.mark.asyncio
 async def test_basic_auth(tmpdir):
     async with temp_gateway(temp_dir=str(tmpdir.join("dask-gateway"))) as gateway_proc:
-
         async with Gateway(
-            address=gateway_proc.public_url, asynchronous=True, auth="basic"
+            address=gateway_proc.public_url,
+            proxy_address=gateway_proc.gateway_url,
+            asynchronous=True,
+            auth="basic",
         ) as gateway:
-
             await gateway.list_clusters()
 
 
@@ -59,9 +60,11 @@ async def test_basic_auth_password(tmpdir):
 
     async with temp_gateway(config=config) as gateway_proc:
         auth = BasicAuth()
-
         async with Gateway(
-            address=gateway_proc.public_url, asynchronous=True, auth=auth
+            address=gateway_proc.public_url,
+            proxy_address=gateway_proc.gateway_url,
+            asynchronous=True,
+            auth=auth,
         ) as gateway:
 
             with pytest.raises(Exception):
@@ -85,7 +88,10 @@ async def test_kerberos_auth(tmpdir):
 
     async with temp_gateway(config=config) as gateway_proc:
         async with Gateway(
-            address=gateway_proc.public_url, asynchronous=True, auth="kerberos"
+            address=gateway_proc.public_url,
+            proxy_address=gateway_proc.gateway_url,
+            asynchronous=True,
+            auth="kerberos",
         ) as gateway:
 
             kdestroy()
@@ -170,7 +176,10 @@ async def test_jupyterhub_auth(tmpdir, monkeypatch):
             auth = JupyterHubAuth(api_token=uuid.uuid4().hex)
 
             async with Gateway(
-                address=gateway_proc.public_url, asynchronous=True, auth=auth
+                address=gateway_proc.public_url,
+                proxy_address=gateway_proc.gateway_url,
+                asynchronous=True,
+                auth=auth,
             ) as gateway:
 
                 # Auth fails with bad token


### PR DESCRIPTION
Previously the REST server would respond to a client request with a full
address (host, port, and routing) for connecting to a dask scheduler
through the scheduler proxy. This caused problems when the REST server
didn't know the *user-facing* address for the scheduler proxy. This
could happen in deployments where there's a difference in internal and
external hosts/IPs (e.g. kubernetes).

Now the user can provide the address of the proxy in the constructor, as
well is in the *user* configuration (i.e. the `gateway.yaml` file). If
not provided, the proxy is assumed to be reachable at the same host as
the REST server, on port 8786 (the default port).