### PR TITLE
Proxies exit with non-zero exit code on error

### DIFF
--- a/dask-gateway-server/dask-gateway-proxy/utils.go
+++ b/dask-gateway-server/dask-gateway-proxy/utils.go
@@ -33,7 +33,7 @@ func withAuthorization(handler http.HandlerFunc, token string) http.HandlerFunc 
 	}
 }
 
-func serveAPI(handler http.HandlerFunc, address string, token string) {
+func serveAPI(handler http.HandlerFunc, address string, token string, logger *Logger) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/routes/", withAuthorization(handler, token))
 
@@ -41,7 +41,11 @@ func serveAPI(handler http.HandlerFunc, address string, token string) {
 		Addr:    address,
 		Handler: mux,
 	}
-	server.ListenAndServe()
+	err := server.ListenAndServe()
+	if err != nil && err != http.ErrServerClosed {
+		logger.Errorf("%s", err)
+		os.Exit(1)
+	}
 }
 
 func awaitShutdown() {

--- a/dask-gateway-server/dask_gateway_server/proxy/core.py
+++ b/dask-gateway-server/dask_gateway_server/proxy/core.py
@@ -299,7 +299,6 @@ class ProxyApp(Application):
         env = proxy.get_start_env()
         exe = command[0]
         args = command[1:]
-        print(args)
         os.execle(exe, "dask-gateway-proxy", *args, env)
 
 

--- a/dask-gateway-server/dask_gateway_server/proxy/core.py
+++ b/dask-gateway-server/dask_gateway_server/proxy/core.py
@@ -299,6 +299,7 @@ class ProxyApp(Application):
         env = proxy.get_start_env()
         exe = command[0]
         args = command[1:]
+        print(args)
         os.execle(exe, "dask-gateway-proxy", *args, env)
 
 

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -292,3 +292,24 @@ async def test_scheduler_proxy(scheduler_proxy, cluster_and_security):
     assert not await scheduler_proxy.get_all_routes()
     # Delete idempotent
     await scheduler_proxy.delete_route("/temp")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cls, scheme, kind",
+    [
+        (SchedulerProxy, "tls", "public"),
+        (SchedulerProxy, "http", "api"),
+        (WebProxy, "http", "public"),
+        (WebProxy, "http", "api"),
+    ],
+)
+async def test_proxy_exits_with_error_code(cls, scheme, kind):
+    kwargs = {"%s_url" % kind: "%s://bad-hostname-here:%d" % (scheme, random_port())}
+    proxy = cls(**kwargs)
+    try:
+        with pytest.raises(RuntimeError) as exc:
+            await proxy.start()
+        assert "exit code 1" in str(exc.value)
+    finally:
+        proxy.stop()

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -305,7 +305,7 @@ async def test_scheduler_proxy(scheduler_proxy, cluster_and_security):
     ],
 )
 async def test_proxy_exits_with_error_code(cls, scheme, kind):
-    kwargs = {"%s_url" % kind: "%s://bad-hostname-here:%d" % (scheme, random_port())}
+    kwargs = {"%s_url" % kind: "%s://bad-hostname-here" % scheme}
     proxy = cls(**kwargs)
     try:
         with pytest.raises(RuntimeError) as exc:


### PR DESCRIPTION
Previously proxies would exit with exit code 0 if there was an error
during initialization (e.g. faulty address). We now catch and log these
errors, and exit with a non-zero exit code in the case of failure.

Fixes #63.