### PR TITLE
Change defaults for easier local experience

### DIFF
--- a/dask-gateway/dask_gateway/gateway.yaml
+++ b/dask-gateway/dask_gateway/gateway.yaml
@@ -7,7 +7,8 @@ gateway:
 
   auth:
     type: basic         # The authentication type to use. Options are basic,
-                        # kerberos, or a full class path to a custom class.
+                        # kerberos, jupyterhub, or a full class path to a
+                        # custom class.
 
     kwargs: {}          # Keyword arguments to use when instantiating the
                         # authentication class above.


### PR DESCRIPTION
This changes the default configuration so that it "just works" when run
locally for demos/experimentation, without need for any additional
configuration.

- Default cluster manager is `UnsafeLocalClusterManager`
- Default authenticator is `DummyAuthenticator`

Note that both of these choices are bad/unsafe for real-world usage, but
any real world deployment will also need to configure other options
anyway.

Users can now try out dask gateway by doing:

```console
$ pip install dask-gateway dask-gateway-server
$ dask-gateway-server
```

And in another terminal:

```python
import dask_gateway
gateway = dask_gateway.Gateway(<address-logged-above>)
cluster = gateway.new_cluster()
```

---

This also fixes a bug in our default configuration, where the hostname
wouldn't be resolved (since traitlets doesn't run validators on default
values).