### PR TITLE
Expose authentication in helm chart

### DIFF
--- a/resources/helm/dask-gateway/templates/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/configmap.yaml
@@ -9,6 +9,11 @@ data:
     {{/* Remove secrets before forwarding configuration */}}
     {{- $values := pick .Values "gateway" "schedulerProxy" "webProxy" }}
     {{- $_ := set $values "gateway" (omit $values.gateway "cookieSecret" "proxyToken") }}
+    {{- if $values.gateway.auth.jupyterhub.apiToken }}
+    {{- $auth := omit $values.gateway.auth }}
+    {{- $_ := set $auth "jupyterhub" (omit $auth.jupyterhub "apiToken") }}
+    {{- $_ := set $values.gateway "auth" $auth }}
+    {{- end }}
     import os
     import json
 
@@ -48,7 +53,7 @@ data:
     c.WebProxy.api_url = web_proxy_api
     c.SchedulerProxy.api_url = scheduler_proxy_api
 
-    # Schedulers aren't managed by the gateway
+    # Proxies aren't managed by the gateway
     c.SchedulerProxy.externally_managed = True
     c.WebProxy.externally_managed = True
 
@@ -92,4 +97,28 @@ data:
             setattr(c.KubeClusterManager, field, value)
 
     # Authentication
-    c.DaskGateway.authenticator_class = "dask_gateway_server.auth.DummyAuthenticator"
+    auth_type = get_property("gateway.auth.type")
+    if auth_type == "dummy":
+        c.DaskGateway.authenticator_class = "dask_gateway_server.auth.DummyAuthenticator"
+        password = get_property("gateway.auth.dummy.password")
+        if password is not None:
+            c.DummyAuthenticator.password = password
+    elif auth_type == "kerberos":
+        c.DaskGateway.authenticator_class = "dask_gateway_server.auth.KerberosAuthenticator"
+        keytab = get_property("gateway.auth.kerberos.keytab")
+        if keytab is not None:
+            c.KerberosAuthenticator.keytab = keytab
+    elif auth_type == "jupyterhub":
+        c.DaskGateway.authenticator_class = "dask_gateway_server.auth.JupyterHubAuthenticator"
+        api_url = get_property("gateway.auth.jupyterhub.apiUrl")
+        if api_url is None:
+            api_url = "http://{HUB_SERVICE_HOST}:{HUB_SERVICE_PORT}".format(**os.environ)
+        c.DaskGateway.JupyterHubAuthenticator.jupyterhub_api_url = api_url
+    elif auth_type == "custom":
+        auth_cls = get_property("gateway.auth.custom.class")
+        c.DaskGateway.authenticator_class = auth_cls
+        auth_cls_name = auth_cls.rsplit('.', 1)[-1]
+        auth_config = c[auth_cls_name]
+        auth_config.update(get_property("gateway.auth.custom.config") or {})
+    else:
+        raise ValueError("Unknown authenticator type %r" % auth_type)

--- a/resources/helm/dask-gateway/templates/gateway-deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway-deployment.yaml
@@ -53,6 +53,13 @@ spec:
                   name: {{ include "dask-gateway.fullname" . }}
                   key: cookie-secret
             {{- end }}
+            {{- if (eq .Values.gateway.auth.type "jupyterhub") }}
+            - name: JUPYTERHUB_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "dask-gateway.fullname" . }}
+                  key: jupyterhub-api-token
+            {{- end }}
             - name: SCHEDULER_PROXY_PUBLIC_SERVICE_NAME
               value: {{ include "dask-gateway.fullname" . | printf "scheduler-public-%s" | trunc 63 | trimSuffix "-" }}
             - name: SCHEDULER_PROXY_API_SERVICE_NAME

--- a/resources/helm/dask-gateway/templates/secret.yaml
+++ b/resources/helm/dask-gateway/templates/secret.yaml
@@ -11,3 +11,7 @@ data:
   {{- if .Values.gateway.cookieSecret }}
   cookie-secret: {{ .Values.gateway.cookieSecret | b64enc | quote }}
   {{- end }}
+
+  {{- if (eq .Values.gateway.auth.type "jupyterhub") }}
+  jupyterhub-api-token: {{ (required "gateway.auth.jupyterhub.apiToken must be defined when using jupyterhub auth" .Values.gateway.auth.jupyterhub.apiToken) | b64enc | quote }}
+  {{- end }}

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -21,11 +21,29 @@ gateway:
     tag: 0.3.0
     pullPolicy: IfNotPresent
 
+  auth:
+    type: dummy
+    dummy:
+      password: null
+    kerberos:
+      keytab: null
+    jupyterhub:
+      apiToken: null
+      apiUrl: null
+    custom:
+      class: null
+      options: {}
+
   clusterManager:
     clusterStartTimeout: null
     clusterConnectTimeout: null
     workerStartTimeout: null
     workerConnectTimeout: null
+
+    image:
+      name: jcrist/dask-gateway
+      tag: 0.3.0
+      pullPolicy: IfNotPresent
 
     environment: null
 


### PR DESCRIPTION
Makes authentication configurable, supporting all 3 builtin methods
(dummy, kerberos, and jupyterhub), as well as a general "custom" class.

Also adds forgotten config defaults for dask scheduler/worker images.
This was supported, but not present in the default `values.yaml` file.