### PR TITLE
Add `gateway.extraConfig` field to helm [ci skip]

### DIFF
--- a/resources/helm/dask-gateway/templates/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/configmap.yaml
@@ -6,9 +6,11 @@ metadata:
     {{- include "dask-gateway.labels" . | nindent 4 }}
 data:
   dask_gateway_config.py: |-
-    {{/* Remove secrets before forwarding configuration */}}
+    {{/* Extract extraConfig, as its handled separately */}}
+    {{- $extraConfig := .Values.gateway.extraConfig }}
+    {{/* Remove secrets and extraConfig before forwarding configuration */}}
     {{- $values := pick .Values "gateway" "schedulerProxy" "webProxy" }}
-    {{- $_ := set $values "gateway" (omit $values.gateway "cookieSecret" "proxyToken") }}
+    {{- $_ := set $values "gateway" (omit $values.gateway "cookieSecret" "proxyToken" "extraConfig") }}
     {{- if $values.gateway.auth.jupyterhub.apiToken }}
     {{- $auth := omit $values.gateway.auth }}
     {{- $_ := set $auth "jupyterhub" (omit $auth.jupyterhub "apiToken") }}
@@ -122,3 +124,15 @@ data:
         auth_config.update(get_property("gateway.auth.custom.config") or {})
     else:
         raise ValueError("Unknown authenticator type %r" % auth_type)
+
+    {{- if $extraConfig }}
+    {{ if kindIs "string" $extraConfig }}
+    # From gateway.extraConfig
+    {{- $extraConfig | nindent 4 }}
+    {{- else }}
+    {{- range $key := keys $extraConfig | sortAlpha }}
+    # From gateway.extraConfig.{{ $key }}
+    {{- index $extraConfig $key | nindent 4 }}
+    {{- end }}
+    {{- end }}
+    {{- end }}

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -63,6 +63,8 @@ gateway:
         request: null
         limit: null
 
+  extraConfig: {}
+
 schedulerProxy:
   annotations: {}
 


### PR DESCRIPTION
Adds a way to include arbitrary configuration code in the helm chart.
Users can add python source code here that will be appended to the end
of the generated `dask_gateway_config.py` file.

This field can accept either a string:

```yaml
gateway:
  extraConfig: |
    c.Foo.bar = 1
    c.Foo.baz = 2
```

Or a map of key to strings

```yaml
gateway:
  extraConfig:
    key1: |
      c.Foo.bar = 1
      c.Foo.baz = 2
    key2: |
      c.Foo.bar = 3
```

The second case allows merging of `extraConfig` values from multiple
yaml files. In this case, the extra code is appended to the end of the
`dask_gateway_config.py` file in alphabetical order by key:

```python
# dask_gateway_config.py
...

c.Foo.bar = 1
c.Foo.baz = 2

c.Foo.bar = 3
```

This can be useful as it allows merging multiple custom configurations
together from separate files in a deterministic manner.