### PR TITLE
Support NodePort in helm chart

### DIFF
--- a/resources/helm/dask-gateway/templates/scheduler-proxy-service.yaml
+++ b/resources/helm/dask-gateway/templates/scheduler-proxy-service.yaml
@@ -37,4 +37,10 @@ spec:
     - protocol: TCP
       port: 8786
       targetPort: 8786
+      {{- if .Values.schedulerProxy.service.nodePort }}
+      nodePort: {{ .Values.schedulerProxy.service.nodePort }}
+      {{- end }}
   type: {{ .Values.schedulerProxy.service.type }}
+  {{- if .Values.schedulerProxy.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.schedulerProxy.service.loadBalancerIP }}
+  {{- end }}

--- a/resources/helm/dask-gateway/templates/web-proxy-service.yaml
+++ b/resources/helm/dask-gateway/templates/web-proxy-service.yaml
@@ -37,4 +37,10 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 8000
+      {{- if .Values.webProxy.service.nodePort }}
+      nodePort: {{ .Values.webProxy.service.nodePort }}
+      {{- end }}
   type: {{ .Values.webProxy.service.type }}
+  {{- if .Values.webProxy.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.webProxy.service.loadBalancerIP }}
+  {{- end }}

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -76,8 +76,10 @@ schedulerProxy:
     pullPolicy: IfNotPresent
 
   service:
-    type: LoadBalancer
     annotations: {}
+    type: LoadBalancer
+    nodePort: null
+    loadBalancerIP: null
 
 webProxy:
   annotations: {}
@@ -90,5 +92,7 @@ webProxy:
     pullPolicy: IfNotPresent
 
   service:
-    type: LoadBalancer
     annotations: {}
+    type: LoadBalancer
+    nodePort: null
+    loadBalancerIP: null

--- a/resources/helm/testing/minikube-config.yaml
+++ b/resources/helm/testing/minikube-config.yaml
@@ -13,3 +13,13 @@ gateway:
         request: 0.1
       memory:
         request: 256M
+
+webProxy:
+  service:
+    type: NodePort
+    nodePort: 30200
+
+schedulerProxy:
+  service:
+    type: NodePort
+    nodePort: 30201


### PR DESCRIPTION
Allow configuring `NodePort` settings in the helm chart. Also allows setting `loadBalancerIP`.

When running locally on minikube, we now use `NodePort` in the testing config.