### PR TITLE
A few URL cleanups

### DIFF
--- a/dask-gateway-server/dask_gateway_server/proxy/core.py
+++ b/dask-gateway-server/dask_gateway_server/proxy/core.py
@@ -126,7 +126,7 @@ class ProxyBase(LoggingConfigurable):
             )
             self.proxy_process = proc
             self.log.info(
-                "Dask gateway %s proxy running at %r, api at %r",
+                "Dask gateway %s proxy started at %r, api at %r",
                 self._subcommand,
                 self.public_url,
                 self.api_url,

--- a/dask-gateway-server/dask_gateway_server/utils.py
+++ b/dask-gateway-server/dask_gateway_server/utils.py
@@ -2,6 +2,7 @@ import asyncio
 import shutil
 import socket
 import weakref
+from urllib.parse import urlparse, urlunparse
 
 from traitlets import Integer, TraitError, Type as _Type
 
@@ -72,6 +73,18 @@ def get_ip():
         sock.close()
 
     raise ValueError("Failed to determine local IP address")
+
+
+def get_connect_urls(url):
+    parsed = urlparse(url)
+    if parsed.hostname in {None, "", "0.0.0.0"}:
+        host = socket.gethostname()
+        hosts = ["127.0.0.1", host]
+    else:
+        hosts = [parsed.hostname]
+    return [
+        urlunparse(parsed._replace(netloc="%s:%i" % (h, parsed.port))) for h in hosts
+    ]
 
 
 def cleanup_tmpdir(log, path):

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -52,16 +52,17 @@ Connect to the gateway
 ----------------------
 
 To connect to the gateway, create a :class:`Gateway` client with the URL output
-above:
+above. By default this is ``http://127.0.0.1:8000``.
 
 .. code-block:: python
 
     >>> from dask_gateway import Gateway
-    >>> gateway = Gateway("<connection-url-from-above>")
-
+    >>> gateway = Gateway("http://127.0.0.1:8000")
+    >>> gateway
+    Gateway<http://127.0.0.1:8000>
 
 To check that everything is setup properly, query the gateway to see any
-existing clusters (should be an empty list):
+existing clusters (should be an empty list).
 
 .. code-block:: python
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
+import socket
+
 import pytest
 from traitlets import HasTraits, TraitError
 
-from dask_gateway_server.utils import Type
+from dask_gateway_server.utils import Type, get_connect_urls
 
 
 def test_Type_traitlet():
@@ -13,3 +15,14 @@ def test_Type_traitlet():
     assert "Failed to import" in str(exc.value)
 
     Foo(typ="dask_gateway_server.managers.local.LocalClusterManager")
+
+
+def test_get_connect_urls():
+    hostname = socket.gethostname()
+    # When binding on all interfaces, report localhost and hostname
+    for url in ["http://:8000", "http://0.0.0.0:8000"]:
+        urls = get_connect_urls(url)
+        assert urls == ["http://127.0.0.1:8000", "http://%s:8000" % hostname]
+    # Otherwise return as is
+    urls = get_connect_urls("http://example.com:8000")
+    assert urls == ["http://example.com:8000"]


### PR DESCRIPTION
This fixes a few things:
- When specified to listen on all interfaces, we previously accidentally resolved to a single ip before listening. We now pass through the original URL unchanged.
- We now offset the URLs that matter in the logs from those that are just logged for debugging. This should make it clearer for users what they need to actually connect.
- For addresses listening on all interfaces, we log both the hostname and localhost as options to connect.