### PR TITLE
Use a random port for the private URL

### DIFF
--- a/dask-gateway-server/dask_gateway_server/app.py
+++ b/dask-gateway-server/dask_gateway_server/app.py
@@ -31,7 +31,14 @@ from .objects import (
 )
 from .options import Options
 from .proxy import SchedulerProxy, WebProxy
-from .utils import cleanup_tmpdir, cancel_task, TaskPool, Type, get_connect_urls
+from .utils import (
+    cleanup_tmpdir,
+    cancel_task,
+    TaskPool,
+    Type,
+    get_connect_urls,
+    random_port,
+)
 
 
 # Override default values for logging
@@ -176,10 +183,18 @@ class DaskGateway(Application):
         return "tls://%s:8786" % host
 
     private_url = Unicode(
-        "http://127.0.0.1:8081",
-        help="The gateway's private URL used for internal communication",
+        help="""
+        The gateway's private URL, used for internal communication.
+
+        This must be reachable from the web proxy, but shouldn't be publicly
+        accessible (if possible). Default is ``http://127.0.0.1:{random-port}``.
+        """,
         config=True,
     )
+
+    @default("private_url")
+    def _default_private_url(self):
+        return "http://127.0.0.1:%d" % random_port()
 
     @validate("public_url", "gateway_url", "private_url")
     def _normalize_url(self, proposal):

--- a/dask-gateway-server/dask_gateway_server/proxy/core.py
+++ b/dask-gateway-server/dask_gateway_server/proxy/core.py
@@ -41,7 +41,7 @@ class ProxyBase(LoggingConfigurable):
 
         This is the address that the Dask Gateway will connect to when
         adding/removing routes. This must be reachable from the Dask Gateway
-        server, but shouldn't be publicly accessible (if possible). Default's
+        server, but shouldn't be publicly accessible (if possible). Defaults
         to ``127.0.0.1:{random-port}``.
         """,
         config=True,


### PR DESCRIPTION
We already did this for the other private URLs (proxy api servers,
etc...). We now do this for the gateway private URL as well. This can be
useful, as users have fewer fixed ports they need to worry about
configuring.