### PR TITLE
Add missing trailing `/hub/api` in helm chart

### DIFF
--- a/resources/helm/dask-gateway/templates/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/configmap.yaml
@@ -114,7 +114,7 @@ data:
         c.DaskGateway.authenticator_class = "dask_gateway_server.auth.JupyterHubAuthenticator"
         api_url = get_property("gateway.auth.jupyterhub.apiUrl")
         if api_url is None:
-            api_url = "http://{HUB_SERVICE_HOST}:{HUB_SERVICE_PORT}".format(**os.environ)
+            api_url = "http://{HUB_SERVICE_HOST}:{HUB_SERVICE_PORT}/hub/api".format(**os.environ)
         c.DaskGateway.JupyterHubAuthenticator.jupyterhub_api_url = api_url
     elif auth_type == "custom":
         auth_cls = get_property("gateway.auth.custom.class")


### PR DESCRIPTION
Without this, jupyterhub authentication using automatic discovery of JupyterHub's api url was broken.