### PR TITLE
[WIP] Add support for user limits

### DIFF
--- a/dask-gateway-server/dask_gateway_server/handlers.py
+++ b/dask-gateway-server/dask_gateway_server/handlers.py
@@ -273,7 +273,12 @@ class ClusterScaleHandler(BaseHandler):
             total = self.json_data["worker_count"]
         except (TypeError, KeyError):
             raise web.HTTPError(422, reason="Malformed request body")
-        await self.gateway.scale(cluster, total)
+        if total < 0:
+            raise web.HTTPError(
+                422, reason="Scale expects a positive integer, got %r" % total
+            )
+        n, msg = await self.gateway.scale(cluster, total)
+        self.write({"n": n, "message": msg})
 
 
 class ClusterWorkersHandler(BaseHandler):

--- a/dask-gateway-server/dask_gateway_server/limits.py
+++ b/dask-gateway-server/dask_gateway_server/limits.py
@@ -1,0 +1,139 @@
+from traitlets import Float, Integer
+from traitlets.config import LoggingConfigurable
+
+from .utils import MemoryLimit, format_bytes
+
+
+class UserLimits(LoggingConfigurable):
+    """Manages restrictions for user resource usage"""
+
+    max_cores = Float(
+        0,
+        help="""
+        The maximum number of cores available for each user.
+
+        Set to 0 for no limit (default).
+        """,
+        min=0.0,
+        config=True,
+    )
+
+    max_memory = MemoryLimit(
+        0,
+        help="""
+        The maximum amount of memory (in bytes) available to each user.
+        Can be an integer, or a string with one of the following suffixes:
+
+        - K -> Kibibytes
+        - M -> Mebibytes
+        - G -> Gibibytes
+        - T -> Tebibytes
+
+        Set to 0 for no limit (default).
+        """,
+        config=True,
+    )
+
+    max_clusters = Integer(
+        0,
+        help="""
+        The maximum number of clusters available for each user.
+
+        Set to 0 for no limit (default).
+        """,
+        min=0,
+        config=True,
+    )
+
+    @property
+    def no_limits(self):
+        return self.max_cores == 0 and self.max_memory == 0 and self.max_clusters == 0
+
+    @staticmethod
+    def _sum_resources(active_clusters):
+        memory = 0
+        cores = 0
+        for cluster in active_clusters:
+            cores += cluster.cores
+            memory += cluster.memory
+            for worker in cluster.active_workers():
+                cores += worker.cores
+                memory += worker.memory
+        return memory, cores
+
+    def check_cluster_limits(self, user, memory, cores):
+        if not (self.max_cores or self.max_memory or self.max_clusters):
+            return True, None
+
+        active_clusters = list(user.active_clusters())
+
+        if self.max_clusters and len(active_clusters) >= self.max_clusters:
+            msg = (
+                "Cannot start new cluster, would exceed user limit of %d active clusters."
+                % self.max_clusters
+            )
+            self.log.info(msg)
+            return False, msg
+
+        active_memory, active_cores = self._sum_resources(active_clusters)
+
+        if self.max_cores and self.max_cores - active_cores < cores:
+            msg = (
+                "Cannot start a new cluster, would exceed user cores limit of %s"
+                % self.max_cores
+            )
+            self.log.info(msg)
+            return False, msg
+
+        if self.max_memory and self.max_memory - active_memory < memory:
+            msg = (
+                "Cannot start a new cluster, would exceed user memory limit of %s"
+                % format_bytes(self.max_memory)
+            )
+            self.log.info(msg)
+            return False, msg
+
+        return True, None
+
+    def check_scale_limits(self, cluster, n, memory, cores):
+        if not (self.max_cores or self.max_memory):
+            return n, None
+
+        active_memory, active_cores = self._sum_resources(
+            cluster.user.active_clusters()
+        )
+
+        if self.max_memory:
+            available_memory = self.max_memory - active_memory
+            n_by_memory = int(available_memory / memory)
+        else:
+            n_by_memory = n
+
+        if self.max_cores:
+            available_cores = self.max_cores - active_cores
+            n_by_cores = int(available_cores / cores)
+        else:
+            n_by_cores = n
+
+        n_allowed = min(n, n_by_cores, n_by_memory)
+
+        if n_allowed < n:
+            if n_by_cores < n_by_memory:
+                # Bound by cores
+                msg = (
+                    "Adding %d workers to cluster %s would exceed user cores "
+                    "limit of %s, adding %d workers instead."
+                    % (n, cluster.name, self.max_cores, n_allowed)
+                )
+            else:
+                # Bound by memory
+                msg = (
+                    "Adding %d workers to cluster %s would exceed user memory "
+                    "limit of %s, adding %d workers instead."
+                    % (n, cluster.name, format_bytes(self.max_cores), n_allowed)
+                )
+            self.log.info(msg)
+        else:
+            msg = None
+
+        return n_allowed, msg

--- a/dask-gateway-server/dask_gateway_server/limits.py
+++ b/dask-gateway-server/dask_gateway_server/limits.py
@@ -45,10 +45,6 @@ class UserLimits(LoggingConfigurable):
         config=True,
     )
 
-    @property
-    def no_limits(self):
-        return self.max_cores == 0 and self.max_memory == 0 and self.max_clusters == 0
-
     @staticmethod
     def _sum_resources(active_clusters):
         memory = 0

--- a/dask-gateway-server/dask_gateway_server/utils.py
+++ b/dask-gateway-server/dask_gateway_server/utils.py
@@ -137,6 +137,21 @@ class MemoryLimit(Integer):
         return int(float(num) * self.UNIT_SUFFIXES[suffix])
 
 
+def format_bytes(nbytes):
+    """Format ``nbytes`` as a human-readable string with units"""
+    if nbytes > 2 ** 50:
+        return "%0.2f PiB" % (nbytes / 2 ** 50)
+    if nbytes > 2 ** 40:
+        return "%0.2f TiB" % (nbytes / 2 ** 40)
+    if nbytes > 2 ** 30:
+        return "%0.2f GiB" % (nbytes / 2 ** 30)
+    if nbytes > 2 ** 20:
+        return "%0.2f MiB" % (nbytes / 2 ** 20)
+    if nbytes > 2 ** 10:
+        return "%0.2f KiB" % (nbytes / 2 ** 10)
+    return "%d B" % nbytes
+
+
 class Type(_Type):
     """An implementation of `Type` with better errors"""
 

--- a/dask-gateway/dask_gateway/__init__.py
+++ b/dask-gateway/dask_gateway/__init__.py
@@ -1,4 +1,10 @@
-from .client import Gateway, GatewayCluster, GatewayClusterError, GatewayServerError
+from .client import (
+    Gateway,
+    GatewayCluster,
+    GatewayClusterError,
+    GatewayServerError,
+    GatewayWarning,
+)
 from .auth import KerberosAuth, BasicAuth
 from .options import Options
 

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -40,9 +40,8 @@ class GatewayServerError(Exception):
     """
 
 
-class UserLimitWarning(UserWarning):
-    """Indicates an operation couldn't fully complete due to user limits
-    on the gateway server."""
+class GatewayWarning(UserWarning):
+    """Warnings raised by the Gateway client"""
 
 
 class GatewaySecurity(Security):
@@ -573,8 +572,7 @@ class Gateway(object):
         resp = await self._fetch(req)
         msg = json.loads(resp.body)
         if msg["message"]:
-            warnings.warn(UserLimitWarning(msg["message"]))
-        return msg["n"]
+            warnings.warn(GatewayWarning(msg["message"]))
 
     def scale_cluster(self, cluster_name, n, **kwargs):
         """Scale a cluster to n workers.
@@ -585,12 +583,6 @@ class Gateway(object):
             The cluster name.
         n : int
             The number of workers to scale to.
-
-        Returns
-        -------
-        n_actual : int
-            The number of workers actually scaled to. This may be different
-            than ``n`` depending on user limits.
         """
         return self.sync(self._scale_cluster, cluster_name, n, **kwargs)
 
@@ -692,12 +684,6 @@ class GatewayCluster(object):
         ----------
         n : int
             The number of workers to scale to.
-
-        Returns
-        -------
-        n_actual : int
-            The number of workers actually scaled to. This may be different
-            than ``n`` depending on user limits.
         """
         return self._gateway.scale_cluster(self.name, n, **kwargs)
 

--- a/docs/source/api-server.rst
+++ b/docs/source/api-server.rst
@@ -23,6 +23,12 @@ Cluster Manager Options
 .. autoclass:: dask_gateway_server.options.Select
 
 
+User Limits
+-----------
+
+.. autoconfigurable:: dask_gateway_server.limits.UserLimits
+
+
 Proxies
 -------
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -60,9 +60,9 @@ async def test_cleanup_expired_clusters(monkeypatch):
     monkeypatch.setattr(time, "time", mytime)
 
     def add_cluster(stop=True):
-        c = db.create_cluster(alice, {})
+        c = db.create_cluster(alice, {}, memory=1e9, cores=1)
         for _ in range(5):
-            w = db.create_worker(c)
+            w = db.create_worker(c, memory=2e9, cores=2)
             if stop:
                 db.update_worker(
                     w,
@@ -125,7 +125,7 @@ async def test_encryption(tmpdir):
     assert data == data2
 
     alice = db.get_or_create_user("alice")
-    c = db.create_cluster(alice, {})
+    c = db.create_cluster(alice, {}, memory=1e9, cores=1)
     assert c.tls_cert is not None
     assert c.tls_key is not None
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -7,7 +7,7 @@ from cryptography.fernet import Fernet
 from traitlets import Integer, Float
 from traitlets.config import Config
 
-from dask_gateway import Gateway, GatewayClusterError
+from dask_gateway import Gateway, GatewayClusterError, GatewayWarning
 from dask_gateway_server.app import DaskGateway
 from dask_gateway_server.compat import get_running_loop
 from dask_gateway_server.objects import ClusterStatus
@@ -753,4 +753,42 @@ async def test_gateway_resume_clusters_after_shutdown(tmpdir):
                 res = await client.submit(lambda x: x + 1, 1)
                 assert res == 2
 
+            await cluster.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_user_limits(tmpdir):
+    config = Config()
+    config.DaskGateway.cluster_manager_class = InProcessClusterManager
+    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.UserLimits.max_clusters = 1
+    config.UserLimits.max_cores = 3
+    config.InProcessClusterManager.scheduler_cores = 1
+    config.InProcessClusterManager.worker_cores = 2
+
+    async with temp_gateway(config=config) as gateway_proc:
+        async with Gateway(
+            address=gateway_proc.public_url,
+            proxy_address=gateway_proc.gateway_url,
+            asynchronous=True,
+        ) as gateway:
+            # Start a cluster
+            cluster = await gateway.new_cluster()
+
+            # Only one cluster allowed
+            with pytest.raises(ValueError) as exc:
+                await gateway.new_cluster()
+            assert "user limit" in str(exc.value)
+
+            # Scaling > 1 triggers a warning, only scales to 1
+            with pytest.warns(GatewayWarning) as rec:
+                await cluster.scale(2)
+            assert len(rec) == 1
+            assert "user cores limit" in str(rec[0].message)
+
+            # Shutdown the cluster
+            await cluster.shutdown()
+
+            # Can create a new cluster after resources returned
+            cluster = await gateway.new_cluster()
             await cluster.shutdown()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -738,7 +738,7 @@ async def test_gateway_resume_clusters_after_shutdown(tmpdir):
         cluster = active_clusters[0]
 
         assert cluster.name == cluster1_name
-        assert len(cluster.active_workers) == 1
+        assert len(cluster.active_workers()) == 1
 
         # Check that cluster is available and everything still works
         async with Gateway(

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,0 +1,113 @@
+import pytest
+
+from dask_gateway_server import objects
+from dask_gateway_server.limits import UserLimits
+
+
+GiB = 2 ** 30
+
+
+@pytest.fixture
+async def db():
+    """Initializes user alice with the following active resources:
+    - 1 cluster
+    - 5 cores
+    - 3 GiB memory
+    """
+    db = objects.DataManager()
+    db.load_database_state()
+
+    alice = db.get_or_create_user("alice")
+
+    # Create one stopped cluster
+    c = db.create_cluster(alice, {}, memory=GiB, cores=1)
+    for _ in range(2):
+        w = db.create_worker(c, memory=GiB, cores=2)
+        db.update_worker(
+            w, status=objects.WorkerStatus.STOPPED, stop_time=objects.timestamp()
+        )
+        db.update_cluster(
+            c, status=objects.ClusterStatus.STOPPED, stop_time=objects.timestamp()
+        )
+
+    # Create one active cluster with 2 active workers, 1 stopped worker
+    c = db.create_cluster(alice, {}, memory=GiB, cores=1)
+    for i in range(3):
+        w = db.create_worker(c, memory=GiB, cores=2)
+        if i == 0:
+            db.update_worker(
+                w, status=objects.WorkerStatus.STOPPED, stop_time=objects.timestamp()
+            )
+    return db
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs,params,warning",
+    [
+        ({"max_clusters": 2}, (GiB, 1), "active clusters"),
+        ({"max_cores": 7}, (GiB, 2), "user cores limit"),
+        ({"max_memory": "5 G"}, (2 * GiB, 2), "user memory limit"),
+    ],
+)
+async def test_check_cluster_limits(kwargs, params, warning, db):
+    alice = db.get_or_create_user("alice")
+
+    limits = UserLimits(**kwargs)
+
+    # Can create cluster
+    allowed, msg = limits.check_cluster_limits(alice, GiB, 1)
+    assert allowed
+    assert msg is None
+
+    # Create cluster
+    db.create_cluster(alice, {}, memory=GiB, cores=1)
+
+    # Cannot create cluster, limit triggered
+    allowed, msg = limits.check_cluster_limits(alice, *params)
+    assert not allowed
+    assert warning in msg
+
+    # With no limit, can create a new cluster
+    limits = UserLimits()
+    allowed, msg = limits.check_cluster_limits(alice, *params)
+    assert allowed
+    assert msg is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs,warning",
+    [
+        ({"max_cores": 11}, "user cores limit"),
+        ({"max_memory": "9 G"}, "user memory limit"),
+    ],
+)
+async def test_check_scale_limits(kwargs, warning, db):
+    alice = db.get_or_create_user("alice")
+
+    limits = UserLimits(**kwargs)
+
+    # Can create cluster
+    allowed, msg = limits.check_cluster_limits(alice, GiB, 1)
+    assert allowed
+    assert msg is None
+
+    # Create cluster
+    cluster = db.create_cluster(alice, {}, memory=GiB, cores=1)
+
+    # Can scale cluster to 2
+    n_allowed, msg = limits.check_scale_limits(cluster, 2, 2 * GiB, 2)
+    assert n_allowed == 2
+    assert msg is None
+
+    # Cannot scale cluster to 3
+    n_allowed, msg = limits.check_scale_limits(cluster, 3, 2 * GiB, 2)
+    assert n_allowed == 2
+    assert warning in msg
+
+    # With no limit, can scale to 3
+    limits = UserLimits()
+    n_allowed, msg = limits.check_scale_limits(cluster, 3, 2 * GiB, 2)
+    assert n_allowed == 3
+    assert msg is None


### PR DESCRIPTION
Adds support for server-side limits of the following:
- Total cores per user
- Total memory per user
- Total clusters per user

From a user, hitting the limits results in:
- An informative error if creating a new cluster would exceed a limit
- A warning if scaling to ``n`` workers would exceed a limit

Fixes #25.

Still needs tests.