### PR TITLE
Remove cluster/worker connect timeouts

### DIFF
--- a/dask-gateway-server/dask_gateway_server/managers/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/base.py
@@ -15,23 +15,9 @@ class ClusterManager(LoggingConfigurable):
     )
 
     cluster_start_timeout = Float(
-        30,
-        help="""
-        Timeout (in seconds) before giving up on a starting dask cluster.
-
-        Note that this is the time for ``start_cluster`` to run, not the time
-        for the cluster to actually respond.
-        """,
-        config=True,
-    )
-
-    cluster_connect_timeout = Float(
         60,
         help="""
-        Timeout (in seconds) for a started dask cluster to connect to the gateway.
-
-        This is the time between ``start_cluster`` completing and the scheduler
-        connecting to the gateway.
+        Timeout (in seconds) before giving up on a starting dask cluster.
         """,
         config=True,
     )
@@ -49,20 +35,9 @@ class ClusterManager(LoggingConfigurable):
     )
 
     worker_start_timeout = Float(
-        30,
-        help="""
-        Timeout (in seconds) before giving up on a starting dask worker.
-        """,
-        config=True,
-    )
-
-    worker_connect_timeout = Float(
         60,
         help="""
-        Timeout (in seconds) for a started dask worker to connect to the scheduler.
-
-        This is the time between ``start_worker`` completing and the worker
-        connecting to the scheduler.
+        Timeout (in seconds) before giving up on a starting dask worker.
         """,
         config=True,
     )

--- a/dask-gateway-server/dask_gateway_server/utils.py
+++ b/dask-gateway-server/dask_gateway_server/utils.py
@@ -6,6 +6,8 @@ from urllib.parse import urlparse, urlunparse
 
 from traitlets import Integer, TraitError, Type as _Type
 
+from .compat import get_running_loop
+
 
 class TaskPool(object):
     def __init__(self):
@@ -67,7 +69,7 @@ class timeout(object):
             self.expired = True
 
     async def __aenter__(self):
-        loop = asyncio.get_running_loop()
+        loop = get_running_loop()
         try:
             self._task = asyncio.current_task(loop=loop)
         except AttributeError:

--- a/docs/source/install-hadoop.rst
+++ b/docs/source/install-hadoop.rst
@@ -370,8 +370,8 @@ also want to increase the cluster/worker timeout values:
 .. code-block:: python
 
     # Increase startup timeouts to 5 min (600 seconds) each
-    c.YarnClusterManager.cluster_connect_timeout = 600
-    c.YarnClusterManager.worker_connect_timeout = 600
+    c.YarnClusterManager.cluster_start_timeout = 600
+    c.YarnClusterManager.worker_start_timeout = 600
 
 
 Example

--- a/resources/helm/dask-gateway/templates/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/configmap.yaml
@@ -90,9 +90,7 @@ data:
         ("image_pull_policy", "image.pullPolicy"),
         ("environment", "environment"),
         ("cluster_start_timeout", "clusterStartTimeout"),
-        ("cluster_connect_timeout", "clusterConnectTimeout"),
         ("worker_start_timeout", "workerStartTimeout"),
-        ("worker_connect_timeout", "workerConnectTimeout"),
     ]:
         value = get_property("gateway.clusterManager." + prop_name)
         if value is not None:

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -36,9 +36,7 @@ gateway:
 
   clusterManager:
     clusterStartTimeout: null
-    clusterConnectTimeout: null
     workerStartTimeout: null
-    workerConnectTimeout: null
 
     image:
       name: jcrist/dask-gateway

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,7 +37,7 @@ def test_generate_config(tmpdir, capfd):
         cfg_text = f.read()
 
     assert "DaskGateway.cluster_manager_class" in cfg_text
-    assert "ClusterManager.worker_connect_timeout" in cfg_text
+    assert "ClusterManager.worker_start_timeout" in cfg_text
 
 
 @pytest.mark.parametrize("kind", ["web", "scheduler"])

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -781,10 +781,8 @@ async def test_user_limits(tmpdir):
             assert "user limit" in str(exc.value)
 
             # Scaling > 1 triggers a warning, only scales to 1
-            with pytest.warns(GatewayWarning) as rec:
+            with pytest.warns(GatewayWarning, match="user cores limit"):
                 await cluster.scale(2)
-            assert len(rec) == 1
-            assert "user cores limit" in str(rec[0].message)
 
             # Shutdown the cluster
             await cluster.shutdown()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -271,7 +271,7 @@ async def test_slow_cluster_connect(tmpdir):
     config = Config()
     config.DaskGateway.cluster_manager_class = SlowStartClusterManager
     config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
-    config.SlowStartClusterManager.cluster_connect_timeout = 0.1
+    config.SlowStartClusterManager.cluster_start_timeout = 0.1
     config.SlowStartClusterManager.pause_time = 0
 
     async with temp_gateway(config=config) as gateway_proc:
@@ -419,7 +419,7 @@ async def test_slow_worker_connect(tmpdir):
     config = Config()
     config.DaskGateway.cluster_manager_class = SlowWorkerStartClusterManager
     config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
-    config.SlowWorkerStartClusterManager.worker_connect_timeout = 0.1
+    config.SlowWorkerStartClusterManager.worker_start_timeout = 0.1
     config.SlowWorkerStartClusterManager.pause_time = 0
 
     async with temp_gateway(config=config) as gateway_proc:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,12 +69,13 @@ async def test_timeout_supports_cancellation():
     async def waiter():
         try:
             async with timeout(2) as t:
+                outer_task.cancel()
                 await inner_task
         finally:
             assert not t.expired
             assert t._waiter is None
 
     outer_task = asyncio.ensure_future(waiter())
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(outer_task, 0.01)
+    with pytest.raises(asyncio.CancelledError):
+        await outer_task
     assert inner_task.cancelled()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,10 @@
+import asyncio
 import socket
 
 import pytest
 from traitlets import HasTraits, TraitError
 
-from dask_gateway_server.utils import Type, get_connect_urls
+from dask_gateway_server.utils import Type, get_connect_urls, timeout
 
 
 def test_Type_traitlet():
@@ -26,3 +27,54 @@ def test_get_connect_urls():
     # Otherwise return as is
     urls = get_connect_urls("http://example.com:8000")
     assert urls == ["http://example.com:8000"]
+
+
+@pytest.mark.asyncio
+async def test_timeout():
+    async def inner():
+        try:
+            await asyncio.sleep(2)
+        except asyncio.CancelledError:
+            raise
+        else:
+            assert False, "Not cancelled"
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout(0.01) as t:
+            await inner()
+    assert t.expired
+
+
+@pytest.mark.asyncio
+async def test_timeout_forwards_exceptions():
+    with pytest.raises(Exception):
+        async with timeout(0.01) as t:
+            raise Exception
+    assert t._waiter is None
+    assert not t.expired
+
+
+@pytest.mark.asyncio
+async def test_timeout_supports_cancellation():
+    # Unrelated CancelledError raises properly
+    with pytest.raises(asyncio.CancelledError):
+        async with timeout(0.01) as t:
+            raise asyncio.CancelledError
+    assert t._waiter is None
+    assert not t.expired
+
+    # Cancelling an outer task cancels the inner and clears the timeout
+    inner_task = asyncio.ensure_future(asyncio.sleep(2))
+
+    async def waiter():
+        try:
+            async with timeout(2) as t:
+                await inner_task
+        finally:
+            assert not t.expired
+            assert t._waiter is None
+
+    outer_task = asyncio.ensure_future(waiter())
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(outer_task, 0.01)
+    assert inner_task.cancelled()


### PR DESCRIPTION
Previously we exposed two separate timeouts for starting scheduler and worker processes:

- `*_start_timeout`: for timeouts when running the `start_*` methods
- `*_connect_timeout`: for timeouts while waiting for the process to connect to the cluster/gateway.

(where `*` is either `cluster` or `worker`)

This was confusing, as how much of the startup process actually fell under each timeout was backend dependent. For example, local processes start up immediately, so the timeout is entirely under the start timeout. In contrast, kubernetes pods are only submitted to be run under the start timeout, and most of the time is waiting for them to connect. The word "start" here is confusing, because neither process is considered fully "started" until the gateway has received a message from it.

To simplify this, we now provide a single `*_start_timeout` config for both `cluster` and `worker`. This timeout is for the entire startup process, from submission to connection. This is both simpler to understand and to configure.